### PR TITLE
feat(ci): separate runner publication from manual compiler dispatch (#19)

### DIFF
--- a/.github/workflows/publish-compiler.yml
+++ b/.github/workflows/publish-compiler.yml
@@ -1,0 +1,140 @@
+name: Publish artifact compiler image
+
+on:
+  workflow_dispatch:
+    inputs:
+      source_sha:
+        description: Full 40-character source commit SHA to compile and publish
+        required: true
+        type: string
+
+permissions:
+  contents: read
+
+jobs:
+  validate:
+    name: Validate on Node 24
+    runs-on: ubuntu-latest
+    steps:
+      - name: Reject invalid source revision
+        run: |
+          if ! [[ "${{ inputs.source_sha }}" =~ ^[0-9a-f]{40}$ ]]; then
+            echo "::error::source_sha must be a full 40-character commit SHA; got '${{ inputs.source_sha }}'"
+            exit 1
+          fi
+
+      - name: Check out exact source revision
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1
+        with:
+          ref: ${{ inputs.source_sha }}
+
+      - name: Verify checked-out revision
+        run: |
+          actual="$(git rev-parse HEAD)"
+          if [ "$actual" != "${{ inputs.source_sha }}" ]; then
+            echo "::error::checked out $actual, expected ${{ inputs.source_sha }}"
+            exit 1
+          fi
+
+      - name: Set up Node 24
+        uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020
+        with:
+          node-version: 24.x
+          cache: npm
+      - name: Install dependencies
+        run: npm ci
+      - name: Run tests
+        run: npm test
+      - name: Typecheck
+        run: npx tsc --noEmit
+      - name: Lint
+        run: npm run lint
+
+  publish:
+    name: Publish compiler image
+    needs: validate
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write
+      id-token: write
+      attestations: write
+    steps:
+      - name: Check out exact source revision
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1
+        with:
+          ref: ${{ inputs.source_sha }}
+
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@96fe6ef7f33517b61c61be40b68a1882f3264fb8
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@bb05f3f5519dd87d3ba754cc423b652a5edd6d2c
+
+      - name: Normalize GHCR owner
+        id: image
+        env:
+          OWNER: ${{ github.repository_owner }}
+        run: |
+          owner="$(printf '%s' "$OWNER" | tr '[:upper:]' '[:lower:]')"
+          printf 'owner=%s\n' "$owner" >> "$GITHUB_OUTPUT"
+
+      - name: Log in to GHCR
+        uses: docker/login-action@dbcb813823bdd20940b903addbd779551569679f
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Extract compiler image metadata
+        id: meta_compiler
+        uses: docker/metadata-action@dc802804100637a589fabce1cb79ff13a1411302
+        with:
+          images: ghcr.io/${{ steps.image.outputs.owner }}/meeet-artifact-compiler
+          # Derive the tag and OCI revision label from the checked-out
+          # revision, not from the workflow-dispatch branch head.
+          context: git
+          tags: |
+            type=sha,format=long,prefix=sha-
+
+      - name: Build and publish compiler
+        id: build_compiler
+        uses: docker/build-push-action@53b7df96c91f9c12dcc8a07bcb9ccacbed38856a
+        with:
+          context: .
+          file: ./Dockerfile
+          target: artifact-compiler
+          platforms: linux/amd64,linux/arm64
+          push: true
+          tags: ${{ steps.meta_compiler.outputs.tags }}
+          labels: ${{ steps.meta_compiler.outputs.labels }}
+          build-args: |
+            NODE_IMAGE=node:24-bookworm-slim@sha256:3638d9a6fe4030bd716be989438248074489337ba3275657f93595428be4fc03
+          cache-from: type=gha,scope=meeet-compiler
+          cache-to: type=gha,mode=max,scope=meeet-compiler
+          # BuildKit publishes the SLSA provenance attestation and SBOM
+          # together with the immutable image.
+          provenance: mode=max
+          sbom: true
+
+      - name: Attest build provenance
+        uses: actions/attest-build-provenance@4d101475d8b20a2381f78447822ac1eab6504dd8
+        with:
+          subject-name: ghcr.io/${{ steps.image.outputs.owner }}/meeet-artifact-compiler
+          subject-digest: ${{ steps.build_compiler.outputs.digest }}
+          push-to-registry: true
+
+      - name: Emit compiler digest
+        env:
+          GHCR_OWNER: ${{ steps.image.outputs.owner }}
+          COMPILER_DIGEST: ${{ steps.build_compiler.outputs.digest }}
+        run: |
+          {
+            echo "### Manually published compiler image"
+            echo
+            echo 'Pair this digest with the runner revision in the operator-owned runtime .env:'
+            echo
+            echo '```dotenv'
+            echo "MEEET_COMPILER_IMAGE=ghcr.io/${GHCR_OWNER}/meeet-artifact-compiler@${COMPILER_DIGEST}"
+            echo '```'
+          } >> "$GITHUB_STEP_SUMMARY"

--- a/.github/workflows/publish-runner.yml
+++ b/.github/workflows/publish-runner.yml
@@ -1,4 +1,4 @@
-name: Publish GHCR images
+name: Publish runner image
 
 on:
   push:
@@ -17,9 +17,9 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Check out source
-        uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1
       - name: Set up Node 24
-        uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020
+        uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020
         with:
           node-version: 24.x
           cache: npm
@@ -33,7 +33,7 @@ jobs:
         run: npm run lint
 
   publish:
-    name: Publish runner and compiler images
+    name: Publish runner image
     needs: validate
     runs-on: ubuntu-latest
     permissions:
@@ -41,13 +41,13 @@ jobs:
       packages: write
     steps:
       - name: Check out source
-        uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1
 
       - name: Set up QEMU
-        uses: docker/setup-qemu-action@c7c53464625b32c7a7e944ae62b3e17d2b600130
+        uses: docker/setup-qemu-action@96fe6ef7f33517b61c61be40b68a1882f3264fb8
 
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@8d2750c68a42422c14e847fe6c8ac0403b4cbd6f
+        uses: docker/setup-buildx-action@bb05f3f5519dd87d3ba754cc423b652a5edd6d2c
 
       - name: Normalize GHCR owner
         id: image
@@ -58,7 +58,7 @@ jobs:
           printf 'owner=%s\n' "$owner" >> "$GITHUB_OUTPUT"
 
       - name: Log in to GHCR
-        uses: docker/login-action@c94ce9fb468520275223c153574b00df6fe4bcc9
+        uses: docker/login-action@dbcb813823bdd20940b903addbd779551569679f
         with:
           registry: ghcr.io
           username: ${{ github.actor }}
@@ -66,7 +66,7 @@ jobs:
 
       - name: Extract runner image metadata
         id: meta_runner
-        uses: docker/metadata-action@c299e40c65443455700f0fdfc63efafe5b349051
+        uses: docker/metadata-action@dc802804100637a589fabce1cb79ff13a1411302
         with:
           images: ghcr.io/${{ steps.image.outputs.owner }}/meeet
           tags: |
@@ -76,7 +76,7 @@ jobs:
 
       - name: Build and publish runner
         id: build_runner
-        uses: docker/build-push-action@10e90e3645eae34f1e60eeb005ba3a3d33f178e8
+        uses: docker/build-push-action@53b7df96c91f9c12dcc8a07bcb9ccacbed38856a
         with:
           context: .
           file: ./Dockerfile
@@ -92,46 +92,17 @@ jobs:
           # BuildKit publishes the SLSA provenance attestation with the image.
           provenance: mode=max
 
-      - name: Extract compiler image metadata
-        id: meta_compiler
-        uses: docker/metadata-action@c299e40c65443455700f0fdfc63efafe5b349051
-        with:
-          images: ghcr.io/${{ steps.image.outputs.owner }}/meeet-artifact-compiler
-          tags: |
-            type=sha,format=long,prefix=sha-
-            type=ref,event=branch
-            type=ref,event=tag
-
-      - name: Build and publish compiler
-        id: build_compiler
-        uses: docker/build-push-action@10e90e3645eae34f1e60eeb005ba3a3d33f178e8
-        with:
-          context: .
-          file: ./Dockerfile
-          target: artifact-compiler
-          platforms: linux/amd64,linux/arm64
-          push: true
-          tags: ${{ steps.meta_compiler.outputs.tags }}
-          labels: ${{ steps.meta_compiler.outputs.labels }}
-          build-args: |
-            NODE_IMAGE=node:24-bookworm-slim@sha256:3638d9a6fe4030bd716be989438248074489337ba3275657f93595428be4fc03
-          cache-from: type=gha,scope=meeet-compiler
-          cache-to: type=gha,mode=max,scope=meeet-compiler
-          provenance: mode=max
-
-      - name: Write digest-pinned deployment references
+      - name: Write digest-pinned deployment reference
         env:
           GHCR_OWNER: ${{ steps.image.outputs.owner }}
           RUNNER_DIGEST: ${{ steps.build_runner.outputs.digest }}
-          COMPILER_DIGEST: ${{ steps.build_compiler.outputs.digest }}
         run: |
           {
-            echo "### Digest-pinned deployment references"
+            echo "### Digest-pinned deployment reference"
             echo
-            echo 'Use these immutable references in deploy/production.env; branch and release tags are publication conveniences only.'
+            echo 'Use this immutable reference in the operator-owned Unraid .env; branch and release tags are publication conveniences only.'
             echo
             echo '```dotenv'
             echo "MEEET_IMAGE=ghcr.io/${GHCR_OWNER}/meeet@${RUNNER_DIGEST}"
-            echo "MEEET_COMPILER_IMAGE=ghcr.io/${GHCR_OWNER}/meeet-artifact-compiler@${COMPILER_DIGEST}"
             echo '```'
           } >> "$GITHUB_STEP_SUMMARY"

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -42,3 +42,18 @@
 - The documented Unraid production profile is operator-owned and distinct from
   the tracked Compose template; do not overwrite it or infer host-specific
   resource limits.
+
+## Compiler publication
+
+- The artifact compiler image is published only by a deliberate, authenticated
+  GitHub Actions dispatch, never by a branch push. Routine pushes build and
+  publish only the backend runner.
+- Trigger a compiler rebuild only after a successful push that changes the
+  compiler image target, compiler/import scripts, the GTFS/artifact model, or
+  their locked dependencies. App-only changes do not trigger it.
+- Dispatch after such a push:
+  `gh workflow run publish-compiler.yml --ref <pushed-branch> -f source_sha=<full-commit-sha>`
+- The dispatch validates the given revision, runs the validation suite, and
+  publishes an immutable `sha-<full-sha>` compiler image with SBOM and
+  provenance. It cannot deploy an application, rotate a schedule artifact,
+  alter the operator-owned deployment, or retag a production image.

--- a/README.md
+++ b/README.md
@@ -23,22 +23,47 @@ this repository, at:
 /boot/config/plugins/compose.manager/projects/meeet
 ```
 
-It has exactly `meeet` and `cloudflared` services. The external runtime `.env`
-contains `TUNNEL_TOKEN`, `MEEET_IMAGE`, and `MEEET_SCHEDULE_HOST_DIR`; the
-schedule directory is `/mnt/user/appdata/meeet/schedule`. There are no host
-ports or local `config.yml`. Cloudflared is
-`cloudflare/cloudflared:latest`, runs `tunnel run`, receives `TUNNEL_TOKEN`, and
-uses the Cloudflare dashboard service `http://meeet:3000`.
+It has three services: a one-shot `compiler`, `meeet`, and `cloudflared`. The
+external runtime `.env` contains `TUNNEL_TOKEN`, `MEEET_IMAGE`,
+`MEEET_COMPILER_IMAGE`, and `MEEET_SCHEDULE_HOST_DIR`; the schedule directory
+is `/mnt/user/appdata/meeet/schedule`. There are no host ports or local
+`config.yml`. Cloudflared is `cloudflare/cloudflared:latest`, runs
+`tunnel run`, receives `TUNNEL_TOKEN`, and uses the Cloudflare dashboard
+service `http://meeet:3000`.
 
-The operator selects the runner image tag or digest in the external `.env`. The
-runner and compiler GHCR packages must be public for unauthenticated host
-pulls, or the host may use a machine account with `read:packages`.
+The operator selects the runner image tag or digest and the compiler digest in
+the external `.env`. The runner and compiler GHCR packages must be public for
+unauthenticated host pulls, or the host may use a machine account with
+`read:packages`.
 
-The live Compose project does not run a compiler service. Rotate the MVV
-artifact manually with the published compiler image; download the official
-archive and write the manifest plus matching hash-named `.v8.bin` to
-`/mnt/user/appdata/meeet/schedule`, then restart `meeet`. The complete procedure
-is in [docs/application-deployment.md](docs/application-deployment.md).
+MVV artifact rotation is automatic at `meeet` startup: the one-shot `compiler`
+service fetches the latest MVV feed and compiles (or keeps) the artifact before
+`meeet` starts. The complete procedure is in
+[docs/application-deployment.md](docs/application-deployment.md).
+
+## Compiler image publication
+
+Routine pushes to `main` build and publish only the backend runner image
+(`publish-runner.yml`). The artifact compiler image is published only through a
+deliberate, authenticated GitHub Actions dispatch (`publish-compiler.yml`) —
+never by a branch push.
+
+Trigger a compiler rebuild only after a successful push that changes the
+compiler image target, compiler/import scripts, the GTFS/artifact model, or
+their locked dependencies. App-only changes do not trigger it.
+
+Dispatch after such a push:
+
+```bash
+gh workflow run publish-compiler.yml --ref <pushed-branch> -f source_sha=<full-commit-sha>
+```
+
+The dispatch validates the given revision, runs the validation suite, and
+publishes an immutable `sha-<full-sha>` compiler image with SBOM and
+provenance. It cannot deploy an application, rotate a schedule artifact, alter
+the operator-owned deployment, or retag a production image. Pair the emitted
+compiler digest with the runner revision in the operator-owned runtime `.env`
+to rotate the artifact.
 
 [`compose.production.yml`](compose.production.yml) remains a separate,
 checked-in hardened repository template. Its strict preflight, token-file

--- a/docs/application-deployment.md
+++ b/docs/application-deployment.md
@@ -30,8 +30,9 @@ The live profile is an operator-owned configuration outside this repository:
 
   The operator chooses the runner tag or digest and the compiler image in the
   external Unraid `.env`; they are not stored in this repository. The compiler
-  image is selected by the operator, for example the digest-pinned value from
-  the publish workflow.
+  image is selected by the operator, for example the digest emitted by the
+  manually dispatched `publish-compiler.yml` workflow (see
+  [Compiler image publication and pairing](#compiler-image-publication-and-pairing)).
 - `MEEET_SCHEDULE_HOST_DIR` is bind-mounted read-only into the app at
   `/opt/meeet/schedule`, and read-write into the compiler at `/output`.
 - The tracked template uses the same shape: `cloudflared` runs
@@ -80,6 +81,51 @@ host with a machine account granted `read:packages` before pulling them.
 Use the runner image tag or digest and the compiler image selected by the
 operator. Changing them or the live `cloudflare/cloudflared:latest` image is an
 external Unraid configuration change.
+
+## Compiler image publication and pairing
+
+The runner image and the artifact-compiler image are published by separate
+workflows:
+
+- Routine pushes to `main` run `publish-runner.yml`, which builds and publishes
+  only the backend runner image (`ghcr.io/tiloheidasch/meeet`). It never
+  touches the compiler target.
+- The compiler image is published only through a deliberate, authenticated
+  GitHub Actions dispatch of `publish-compiler.yml`, never by a branch push.
+  Trigger it only after a successful push that changes the compiler image
+  target, compiler/import scripts, the GTFS/artifact model, or their locked
+  dependencies; app-only changes do not trigger it:
+
+  ```bash
+  gh workflow run publish-compiler.yml --ref <pushed-branch> -f source_sha=<full-commit-sha>
+  ```
+
+  The dispatch validates the given revision, runs the validation suite, and
+  publishes an immutable `sha-<full-sha>` multi-platform image with SBOM,
+  provenance, and attestation. It cannot deploy an application, rotate a
+  schedule artifact, alter the operator-owned Unraid deployment, or retag a
+  production image; the workflow summary emits the compiler digest.
+
+To rotate the MVV artifact, the operator pairs the manually published compiler
+digest with the runner revision in the external Unraid `.env`:
+
+```dotenv
+MEEET_IMAGE=ghcr.io/tiloheidasch/meeet:sha-<runner-commit>
+MEEET_COMPILER_IMAGE=ghcr.io/tiloheidasch/meeet-artifact-compiler@sha256:<compiler-digest>
+```
+
+At startup the one-shot `compiler` service runs exactly that compiler image.
+Because the artifact manifest records the compiler version
+(`meeet-scheduled-compiler/v1`), a different compiler digest recompiles the
+artifact even when the underlying feed data is unchanged, which is what makes a
+new compiler revision effective for rotation.
+
+Deployment and rollback stay operator-controlled digest selection: the digest
+pairs are explicit values in the external `.env`, never automatic. To roll
+back, point `MEEET_COMPILER_IMAGE` (and `MEEET_IMAGE` if the runner revision
+should move with it) back at a previously archived digest pair and restart;
+keep the archived manifest and `.v8.bin` rollback pair from the previous
+rotation as described below.
 
 ## MVV artifact rotation
 

--- a/test/workflow-guard.test.ts
+++ b/test/workflow-guard.test.ts
@@ -1,0 +1,99 @@
+import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
+import { fileURLToPath } from "node:url";
+import test from "node:test";
+
+const read = (relativePath: string): string =>
+  readFileSync(fileURLToPath(new URL(`../${relativePath}`, import.meta.url)), "utf8");
+
+const compilerWorkflow = read(".github/workflows/publish-compiler.yml");
+const runnerWorkflow = read(".github/workflows/publish-runner.yml");
+const agentsGuide = read("AGENTS.md");
+const readme = read("README.md");
+
+const triggerBlock = (workflow: string): string => {
+  const match = workflow.match(/^on:([\s\S]*?)^permissions:/m);
+  assert.ok(match, "workflow must declare an on: trigger block followed by top-level permissions:");
+  return match[1];
+};
+
+const publishJob = (workflow: string): string => {
+  const start = workflow.indexOf("  publish:");
+  assert.ok(start >= 0, "workflow must declare a publish job");
+  return workflow.slice(start);
+};
+
+test("compiler publication is workflow_dispatch-only and cannot be reached by push events", () => {
+  const triggers = triggerBlock(compilerWorkflow);
+  assert.match(triggers, /workflow_dispatch/);
+  assert.doesNotMatch(triggers, /^\s*push:/m);
+});
+
+test("compiler dispatch requires and validates an explicit full source SHA", () => {
+  assert.match(compilerWorkflow, /source_sha/);
+  assert.match(compilerWorkflow, /required:\s*true/);
+  assert.match(compilerWorkflow, /\^\[0-9a-f\]\{40\}\$/);
+  assert.match(compilerWorkflow, /ref:\s*\${{ inputs\.source_sha }}/);
+  assert.match(compilerWorkflow, /Verify checked-out revision/);
+});
+
+test("compiler workflow publishes only the immutable sha-<full-sha> compiler image", () => {
+  assert.match(publishJob(compilerWorkflow), /target:\s*artifact-compiler/);
+  assert.match(publishJob(compilerWorkflow), /platforms:\s*linux\/amd64,linux\/arm64/);
+  assert.match(publishJob(compilerWorkflow), /type=sha,format=long,prefix=sha-/);
+  assert.doesNotMatch(publishJob(compilerWorkflow), /type=ref/);
+  assert.match(publishJob(compilerWorkflow), /context:\s*git/);
+  assert.match(publishJob(compilerWorkflow), /provenance:\s*mode=max/);
+  assert.match(publishJob(compilerWorkflow), /sbom:\s*true/);
+  assert.match(publishJob(compilerWorkflow), /attest-build-provenance/);
+  assert.match(publishJob(compilerWorkflow), /outputs\.digest/);
+});
+
+test("compiler publication cannot deploy, rotate artifacts, or retag production images", () => {
+  const forbidden = [/compose/, /cloudflared/, /TUNNEL_TOKEN/, /MEEET_IMAGE/, /unraid/, /\bdeploy\b/, /\bschedule\b/];
+  for (const pattern of forbidden) {
+    assert.doesNotMatch(compilerWorkflow, pattern, `compiler workflow must not reference ${pattern}`);
+  }
+});
+
+test("routine runner publication stays compiler-free and dispatch-free", () => {
+  assert.match(triggerBlock(runnerWorkflow), /^\s*push:/m);
+  assert.doesNotMatch(runnerWorkflow, /artifact-compiler/);
+  assert.match(publishJob(runnerWorkflow), /target:\s*runner/);
+  const imageLines = runnerWorkflow.match(/^[ \t]+images:\s*ghcr\.io\/.*$/gm);
+  assert.ok(imageLines && imageLines.length === 1, "runner workflow must publish exactly one image");
+  assert.doesNotMatch(imageLines![0], /artifact-compiler/);
+});
+
+test("each workflow grants registry and attestation writes only in its publish job", () => {
+  for (const workflow of [compilerWorkflow, runnerWorkflow]) {
+    const beforePublish = workflow.slice(0, workflow.indexOf("  publish:"));
+    assert.doesNotMatch(beforePublish, /packages:\s*write/);
+    assert.match(publishJob(workflow), /packages:\s*write/);
+    assert.match(workflow, /^permissions:\n  contents:\s*read/m);
+  }
+  assert.match(publishJob(compilerWorkflow), /id-token:\s*write/);
+  assert.match(publishJob(compilerWorkflow), /attestations:\s*write/);
+  assert.doesNotMatch(runnerWorkflow, /id-token|attestations/);
+});
+
+test("documented dispatch command matches the compiler workflow and carries no credentials", () => {
+  const commandPattern = /gh workflow run publish-compiler\.yml --ref <[^>]+> -f source_sha=<[^>]+>/;
+  for (const doc of [agentsGuide, readme]) {
+    assert.match(doc, commandPattern);
+    assert.doesNotMatch(doc, /https?:\/\/[^\s]*api\.github\.com|webhook|ghp_|github_pat_/i);
+  }
+  const command = agentsGuide.match(commandPattern);
+  assert.ok(command);
+  assert.match(command[0], /source_sha=<full-commit-sha>/);
+});
+
+test("agent and README documentation state the compiler rebuild trigger conditions", () => {
+  for (const doc of [agentsGuide, readme]) {
+    assert.match(doc, /compiler image target/);
+    assert.match(doc, /compiler\/import scripts|import scripts/);
+    assert.match(doc, /GTFS\/artifact model|GTFS|artifact model/);
+    assert.match(doc, /locked dependencies/);
+    assert.match(doc, /App-only changes do not trigger/i);
+  }
+});


### PR DESCRIPTION
Closes #19

## Summary
- Separates routine runner CI publication from manual compiler publication.
- Moves routine runner publishing into `.github/workflows/publish-runner.yml` (compiler target excluded).
- Adds `.github/workflows/publish-compiler.yml` with `workflow_dispatch` only, requiring a validated 40-hex SHA.
- Publishes multi-platform immutable `sha-<full-sha>` images with SBOM, provenance, OCI revision labels, and digest output.
- Documents dispatch triggers, operator artifact rotation, and rollback in `AGENTS.md`, `README.md`, and `docs/application-deployment.md`.
- Adds comprehensive workflow guard tests in `test/workflow-guard.test.ts`.