### PR TITLE
fix(ci): pass explicit source sha to compiler metadata action (#19)

### DIFF
--- a/.github/workflows/publish-compiler.yml
+++ b/.github/workflows/publish-compiler.yml
@@ -91,11 +91,10 @@ jobs:
         uses: docker/metadata-action@dc802804100637a589fabce1cb79ff13a1411302
         with:
           images: ghcr.io/${{ steps.image.outputs.owner }}/meeet-artifact-compiler
-          # Derive the tag and OCI revision label from the checked-out
-          # revision, not from the workflow-dispatch branch head.
-          context: git
           tags: |
-            type=sha,format=long,prefix=sha-
+            type=raw,value=sha-${{ inputs.source_sha }}
+          labels: |
+            org.opencontainers.image.revision=${{ inputs.source_sha }}
 
       - name: Build and publish compiler
         id: build_compiler

--- a/test/workflow-guard.test.ts
+++ b/test/workflow-guard.test.ts
@@ -40,9 +40,9 @@ test("compiler dispatch requires and validates an explicit full source SHA", () 
 test("compiler workflow publishes only the immutable sha-<full-sha> compiler image", () => {
   assert.match(publishJob(compilerWorkflow), /target:\s*artifact-compiler/);
   assert.match(publishJob(compilerWorkflow), /platforms:\s*linux\/amd64,linux\/arm64/);
-  assert.match(publishJob(compilerWorkflow), /type=sha,format=long,prefix=sha-/);
+  assert.match(publishJob(compilerWorkflow), /type=raw,value=sha-\${{\s*inputs\.source_sha\s*}}/);
   assert.doesNotMatch(publishJob(compilerWorkflow), /type=ref/);
-  assert.match(publishJob(compilerWorkflow), /context:\s*git/);
+  assert.match(publishJob(compilerWorkflow), /org\.opencontainers\.image\.revision=\${{\s*inputs\.source_sha\s*}}/);
   assert.match(publishJob(compilerWorkflow), /provenance:\s*mode=max/);
   assert.match(publishJob(compilerWorkflow), /sbom:\s*true/);
   assert.match(publishJob(compilerWorkflow), /attest-build-provenance/);


### PR DESCRIPTION
Closes #19

## Summary
- Configures `docker/metadata-action` in `.github/workflows/publish-compiler.yml` with explicit `type=raw,value=sha-${{ inputs.source_sha }}` and `org.opencontainers.image.revision=${{ inputs.source_sha }}`.
- Eliminates `context: git` which caused `Cannot infer ref from detached HEAD` error when checking out explicit commit SHAs during manual dispatch.
- Updates workflow guard assertions in `test/workflow-guard.test.ts`.