### PR TITLE
feat(ui): order station icons by mode with spec size hierarchy (#39)

### DIFF
--- a/components/MapLibreCanvas.tsx
+++ b/components/MapLibreCanvas.tsx
@@ -5,6 +5,7 @@ import { AttributionControl, Map, Marker, NavigationControl, setWorkerUrl, type 
 import "maplibre-gl/dist/maplibre-gl.css";
 import type { MeetingStationArea, StationAreaMode } from "@/lib/client/meeting-response";
 import { buildStationTerritories, type StationTerritory } from "@/lib/client/station-territories";
+import { STATION_ICON_PADDING, STATION_ICON_VISUAL_SIZES } from "@/lib/client/station-icon-sizes";
 
 export type MapParticipant = { id: string; number: number; label: string; latitude: number; longitude: number; color: "#e85d4a" | "#3d70c9" };
 type Props = { participants: readonly MapParticipant[]; stationAreas: readonly MeetingStationArea[]; resultState: "initial" | "ok" | "no-result"; selectedStationAreaId?: string | null; onStationAreaSelect?: (stationAreaId: string) => void };
@@ -13,9 +14,10 @@ type FeatureCollection = { type: "FeatureCollection"; features: Array<{ type: "F
 const MUNICH_CENTER: [number, number] = [11.576, 48.137];
 const DEFAULT_MAP_STYLE_URL = "https://tiles.openfreemap.org/styles/liberty";
 const TERRITORY_FILL_OPACITY = 0.4;
-const STATION_LAYERS = ["meeet-stations-red", "meeet-stations-blue", "meeet-stations-fair", "meeet-stations-unclassified"];
+/** Station icon layers in paint order, bottommost first: bus < tram < ubahn < sbahn. */
+const STATION_ICON_PAINT_ORDER: readonly StationAreaMode[] = ["bus", "tram", "ubahn", "sbahn"];
+const STATION_ICON_LAYERS = STATION_ICON_PAINT_ORDER.map((mode) => `meeet-stations-${mode}`);
 const STATION_COLORS = { red: "#e85d4a", blue: "#3d70c9", fair: "#f0ca43", unclassified: "#65716a" } as const;
-const STATION_MODES: readonly StationAreaMode[] = ["sbahn", "ubahn", "tram", "bus"] as const;
 setWorkerUrl("/vendor/maplibre-gl/maplibre-gl-worker.mjs");
 
 const S_PATH_D = "M 472 131 L 471 132 L 458 132 L 457 133 L 448 133 L 447 134 L 434 135 L 433 136 L 428 136 L 398 143 L 376 150 L 356 158 L 330 171 L 312 182 L 286 202 L 265 223 L 253 238 L 242 255 L 229 282 L 223 300 L 219 317 L 218 329 L 217 330 L 217 340 L 216 341 L 217 384 L 218 385 L 220 403 L 227 428 L 231 438 L 243 461 L 249 470 L 266 490 L 292 512 L 319 529 L 350 544 L 406 564 L 409 564 L 416 567 L 444 574 L 448 576 L 455 577 L 459 579 L 496 588 L 500 590 L 507 591 L 546 603 L 549 605 L 557 607 L 572 614 L 574 614 L 590 622 L 604 631 L 622 647 L 630 658 L 636 670 L 640 687 L 640 705 L 637 716 L 632 726 L 624 737 L 608 752 L 596 760 L 578 769 L 564 774 L 548 778 L 537 779 L 536 780 L 496 781 L 495 780 L 483 780 L 482 779 L 468 778 L 467 777 L 462 777 L 461 776 L 456 776 L 446 773 L 442 773 L 405 762 L 402 760 L 387 755 L 380 751 L 378 751 L 343 733 L 312 713 L 276 684 L 248 656 L 232 637 L 222 623 L 222 770 L 248 791 L 290 817 L 332 837 L 352 845 L 360 847 L 363 849 L 366 849 L 369 851 L 375 852 L 395 859 L 419 865 L 423 865 L 428 867 L 443 869 L 444 870 L 450 870 L 451 871 L 463 872 L 464 873 L 472 873 L 473 874 L 501 875 L 502 876 L 542 875 L 543 874 L 561 873 L 562 872 L 568 872 L 569 871 L 590 868 L 610 863 L 617 860 L 620 860 L 647 850 L 674 837 L 700 821 L 728 799 L 751 776 L 767 756 L 777 741 L 793 711 L 799 696 L 806 673 L 806 669 L 809 658 L 809 652 L 810 651 L 810 642 L 811 641 L 810 600 L 809 599 L 809 592 L 808 591 L 806 576 L 798 550 L 789 531 L 778 514 L 771 505 L 752 486 L 726 467 L 694 450 L 692 450 L 667 439 L 619 424 L 571 412 L 554 409 L 541 405 L 537 405 L 505 397 L 501 395 L 494 394 L 477 388 L 474 388 L 443 376 L 421 364 L 409 355 L 398 344 L 392 336 L 386 325 L 382 313 L 381 302 L 380 301 L 380 284 L 381 283 L 382 274 L 390 256 L 404 240 L 418 230 L 441 220 L 458 217 L 459 216 L 466 216 L 467 215 L 508 215 L 509 216 L 519 216 L 520 217 L 527 217 L 528 218 L 546 220 L 572 226 L 603 236 L 623 245 L 625 245 L 662 264 L 689 281 L 716 301 L 752 333 L 766 348 L 766 225 L 743 208 L 721 194 L 679 172 L 677 172 L 670 168 L 645 158 L 603 145 L 595 144 L 576 139 L 566 138 L 565 137 L 559 137 L 558 136 L 552 136 L 544 134 L 536 134 L 535 133 L 508 132 L 507 131 Z";
@@ -51,8 +53,8 @@ function stationData(areas: readonly MeetingStationArea[]): FeatureCollection {
 /** Padded high-DPI station glyph icon rendered on a canvas. */
 function stationGlyphImage(mode: StationAreaMode, color: string): ImageData {
   const pixelRatio = 2;
-  const visualSize = 18;
-  const padding = 11;
+  const visualSize = STATION_ICON_VISUAL_SIZES[mode];
+  const padding = STATION_ICON_PADDING;
   const totalSize = visualSize + padding * 2;
   const canvas = document.createElement("canvas");
   canvas.width = totalSize * pixelRatio;
@@ -144,8 +146,8 @@ function stationGlyphImage(mode: StationAreaMode, color: string): ImageData {
 /** Padded high-DPI selection outline indicator for selected station area. */
 function selectedStationOutlineImage(mode: StationAreaMode): ImageData {
   const pixelRatio = 2;
-  const visualSize = 18;
-  const padding = 11;
+  const visualSize = STATION_ICON_VISUAL_SIZES[mode];
+  const padding = STATION_ICON_PADDING;
   const totalSize = visualSize + padding * 2;
   const canvas = document.createElement("canvas");
   canvas.width = totalSize * pixelRatio;
@@ -261,21 +263,23 @@ export default function MapLibreCanvas({ participants, stationAreas, resultState
 
         map.addSource("meeet-station-areas", { type: "geojson", data: stationData([]) });
 
-        STATION_MODES.forEach((mode) => {
+        STATION_ICON_PAINT_ORDER.forEach((mode) => {
           (["red", "blue", "fair", "unclassified"] as const).forEach((classification) => {
             map!.addImage(`meeet-station-${mode}-${classification}`, stationGlyphImage(mode, STATION_COLORS[classification]), { pixelRatio: 2 });
           });
           map!.addImage(`meeet-selected-station-${mode}`, selectedStationOutlineImage(mode), { pixelRatio: 2 });
         });
 
-        (["red", "blue", "fair", "unclassified"] as const).forEach((classification) => {
+        STATION_ICON_PAINT_ORDER.forEach((mode) => {
           map!.addLayer({
-            id: `meeet-stations-${classification}`,
+            id: `meeet-stations-${mode}`,
             type: "symbol",
             source: "meeet-station-areas",
-            filter: ["==", ["get", "classification"], classification],
+            // The coalesce keeps the pre-existing defensive bus default for features without a mode
+            // (unreachable via stationData, which always sets mode).
+            filter: ["==", ["coalesce", ["get", "mode"], "bus"], mode],
             layout: {
-              "icon-image": ["concat", "meeet-station-", ["coalesce", ["get", "mode"], "bus"], `-${classification}`],
+              "icon-image": ["concat", `meeet-station-${mode}-`, ["get", "classification"]],
               "icon-allow-overlap": true,
               "icon-ignore-placement": true,
               "icon-anchor": "center",
@@ -283,6 +287,9 @@ export default function MapLibreCanvas({ participants, stationAreas, resultState
           });
         });
 
+        // The selection outline is intentionally the topmost canvas layer: it is the selected
+        // station's selection indicator (not a transit icon in the ordering) and must wrap the
+        // icon to be visible.
         map.addLayer({
           id: "meeet-selected-station-area",
           type: "symbol",
@@ -310,9 +317,9 @@ export default function MapLibreCanvas({ participants, stationAreas, resultState
         };
         const hideTooltip = () => setTooltip(null);
 
-        map.on("click", STATION_LAYERS, select);
+        map.on("click", STATION_ICON_LAYERS, select);
         map.on("mouseout", hideTooltip);
-        STATION_LAYERS.forEach((layer) => {
+        STATION_ICON_LAYERS.forEach((layer) => {
           map!.on("mouseenter", layer, () => { map!.getCanvas().style.cursor = "pointer"; });
           map!.on("mouseleave", layer, () => { map!.getCanvas().style.cursor = ""; });
           map!.on("mouseenter", layer, hover);
@@ -352,7 +359,7 @@ export default function MapLibreCanvas({ participants, stationAreas, resultState
     syncOrigins(map, participants, markersRef);
     const markReady = () => {
       if (!map || map !== mapRef.current) return;
-      const ready = stationAreas.length === 0 || stationAreas.every((area) => map.queryRenderedFeatures(map.project([area.coordinate.longitude, area.coordinate.latitude]), { layers: STATION_LAYERS }).some((feature) => feature.properties?.stationAreaId === area.stationAreaId));
+      const ready = stationAreas.length === 0 || stationAreas.every((area) => map.queryRenderedFeatures(map.project([area.coordinate.longitude, area.coordinate.latitude]), { layers: STATION_ICON_LAYERS }).some((feature) => feature.properties?.stationAreaId === area.stationAreaId));
       if (ready) setMarkersReady(true);
     };
     map.once("idle", markReady);

--- a/e2e/meeting.spec.ts
+++ b/e2e/meeting.spec.ts
@@ -2,6 +2,7 @@ import { expect, test, type Page } from "@playwright/test";
 import { inflateSync } from "node:zlib";
 import http from "node:http";
 import type net from "node:net";
+import { STATION_ICON_PADDING, STATION_ICON_SPEC_RATIOS } from "../lib/client/station-icon-sizes";
 
 const MAP_STYLE = "https://tiles.openfreemap.org/styles/liberty";
 const MAP_ORIGIN = "https://tiles.openfreemap.org";
@@ -295,11 +296,32 @@ test.describe("v3 Munich meeting surface", () => {
     const origin1Text = await origin1.textContent();
     expect(origin1Text?.trim()).toBe("");
 
-    // Station markers on MapLibre canvas use symbol layers
+    // Participant pins are DOM markers above the canvas: no icon occludes them
+    // (scroll the map into view first so the markers are inside the viewport for element hit-testing)
+    await page.locator(".map-frame").evaluate((frame) => frame.scrollIntoView({ block: "center" }));
+    const originPinsOnTop = await page.evaluate(() => {
+      return [...document.querySelectorAll(".meeet-origin-marker")].map((marker) => {
+        const rect = marker.getBoundingClientRect();
+        const points = [
+          { x: rect.x + rect.width / 2, y: rect.y + rect.height / 2 },
+          { x: rect.x + 1, y: rect.y + 1 },
+          { x: rect.x + rect.width - 1, y: rect.y + 1 },
+          { x: rect.x + 1, y: rect.y + rect.height - 1 },
+          { x: rect.x + rect.width - 1, y: rect.y + rect.height - 1 },
+        ];
+        return points.every((point) => {
+          const top = document.elementsFromPoint(point.x, point.y)[0];
+          return !!top && top.closest(".meeet-origin-marker") !== null;
+        });
+      });
+    });
+    expect(originPinsOnTop).toEqual([true, true]);
+
+    // Station markers on MapLibre canvas use per-mode symbol layers
     const layerTypes = await page.evaluate(() => {
       const map = (window as unknown as { __meeetMap?: { getLayer: (id: string) => { type: string } | undefined; getLayoutProperty: (id: string, name: string) => unknown } }).__meeetMap;
       if (!map) throw new Error("Map instance unavailable");
-      return ["meeet-stations-red", "meeet-stations-blue", "meeet-stations-fair", "meeet-stations-unclassified"].map((id) => {
+      return ["meeet-stations-bus", "meeet-stations-tram", "meeet-stations-ubahn", "meeet-stations-sbahn"].map((id) => {
         const layer = map.getLayer(id);
         const image = map.getLayoutProperty(id, "icon-image");
         return { id, type: layer?.type, image };
@@ -309,6 +331,40 @@ test.describe("v3 Munich meeting surface", () => {
       expect(layer.type).toBe("symbol");
       expect(layer.image).toBeDefined();
     }
+
+    // Strict paint order: bus < tram < ubahn < sbahn < selection outline; participant pins are DOM markers above the canvas (asserted above)
+    const layerOrder = await page.evaluate(() => {
+      const map = (window as unknown as { __meeetMap?: { getStyle: () => { layers: Array<{ id: string }> } } }).__meeetMap;
+      if (!map) throw new Error("Map instance unavailable");
+      return map.getStyle().layers.map((layer) => layer.id);
+    });
+    const indexOf = (id: string) => layerOrder.indexOf(id);
+    expect(indexOf("meeet-stations-bus")).toBeGreaterThanOrEqual(0);
+    expect(indexOf("meeet-stations-tram")).toBeGreaterThan(indexOf("meeet-stations-bus"));
+    expect(indexOf("meeet-stations-ubahn")).toBeGreaterThan(indexOf("meeet-stations-tram"));
+    expect(indexOf("meeet-stations-sbahn")).toBeGreaterThan(indexOf("meeet-stations-ubahn"));
+    expect(indexOf("meeet-selected-station-area")).toBeGreaterThan(indexOf("meeet-stations-sbahn"));
+
+    // Size hierarchy matches the issue #39 spec ratios: sbahn 200%, ubahn 166%, tram 133%, bus 100% of the bus visual size
+    // (visual size = image width / pixelRatio minus the padding on each side)
+    const iconSizes = await page.evaluate((iconPadding: number) => {
+      const map = (window as unknown as { __meeetMap?: { getImage: (id: string) => { data: { width: number }; pixelRatio: number } | undefined } }).__meeetMap;
+      if (!map) throw new Error("Map instance unavailable");
+      const visualSize = (id: string) => {
+        const image = map.getImage(id);
+        if (!image) throw new Error(`Image ${id} missing`);
+        return image.data.width / image.pixelRatio - 2 * iconPadding;
+      };
+      return {
+        sbahn: visualSize("meeet-station-sbahn-red"),
+        ubahn: visualSize("meeet-station-ubahn-red"),
+        tram: visualSize("meeet-station-tram-red"),
+        bus: visualSize("meeet-station-bus-red"),
+      };
+    }, STATION_ICON_PADDING);
+    expect(iconSizes.sbahn / iconSizes.bus).toBeCloseTo(STATION_ICON_SPEC_RATIOS.sbahn, 5);
+    expect(iconSizes.ubahn / iconSizes.bus).toBeCloseTo(STATION_ICON_SPEC_RATIOS.ubahn, 5);
+    expect(iconSizes.tram / iconSizes.bus).toBeCloseTo(STATION_ICON_SPEC_RATIOS.tram, 5);
 
     // Legend swatches for all classifications are visible
     for (const color of ["red", "blue", "fair", "neutral"]) {

--- a/lib/client/station-icon-sizes.ts
+++ b/lib/client/station-icon-sizes.ts
@@ -1,0 +1,10 @@
+import type { StationAreaMode } from "@/lib/client/meeting-response";
+
+/** Intended display scale of each station icon in CSS pixels (bus = 100% baseline; sbahn 200%, ubahn 166%, tram 133%). */
+export const STATION_ICON_VISUAL_SIZES: Record<StationAreaMode, number> = { bus: 18, tram: 24, ubahn: 30, sbahn: 36 };
+
+/** Spec ratios from issue #39: sbahn 200%, ubahn 166%, tram 133%, bus 100% of the bus visual size. */
+export const STATION_ICON_SPEC_RATIOS: Record<StationAreaMode, number> = { bus: 1, tram: 4 / 3, ubahn: 5 / 3, sbahn: 2 };
+
+/** Padding around the station glyph visual size on each side, in CSS pixels. */
+export const STATION_ICON_PADDING = 11;


### PR DESCRIPTION
Closes #39

## Summary

Establishes a strict visual layer ordering and an intentional size hierarchy for all rendered map icons.

### Layer ordering (topmost first)
participant > S-Bahn > U-Bahn > tram > bus

- Station symbol layers restructured from per-classification to per-mode (`meeet-stations-bus|tram|ubahn|sbahn`), added bottommost-first so paint order yields bus < tram < ubahn < sbahn.
- Participant origin pins are DOM markers above the canvas; the e2e suite now asserts no icon occludes them (5-point hit-test across the full marker area).
- The selection outline remains the topmost canvas layer, documented as the selected station's indicator (not a transit icon in the ordering).

### Size hierarchy (bus = 100%)
- S-Bahn 200% (36px), U-Bahn 166% (30px), Tram 133% (24px), Bus 100% (18px) — applied to the icon's intended display scale, not its bounding box; the selection outline scales with its icon.

### Shared contract
New `lib/client/station-icon-sizes.ts` hosts the icon sizes, padding, and the issue #39 spec ratios as a single source of truth consumed by both the component and the e2e suite.

## Verification
- `npm test` — 226 pass
- `npx tsc --noEmit` — clean
- `npm run lint` — 0 errors
- `git diff --check` — clean
- `npm run test:e2e` — 27/27 (includes new paint-order, size-ratio, and occlusion assertions)

No changes to scheduled calculation behavior, server code, or docs.