### PR TITLE
feat(ci): branch-based development, GHCR publication, compiled-artifact e2e gate (#18)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -30,9 +30,12 @@ jobs:
         run: npm ci
       - name: Build application
         run: npm run build
+      - name: Compile fixture schedule artifact
+        run: npm run schedule:compile:fixture -- --output /tmp/mvv-scheduled-artifact.json
       - name: Start meeet
         env:
           MEEET_PROVIDER_MODE: fixture
+          MEEET_SCHEDULE_ARTIFACT_PATH: /tmp/mvv-scheduled-artifact.json
         run: |
           npm start > /tmp/meeet-server.log 2>&1 &
           echo $! > /tmp/meeet-server.pid

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,55 @@
+name: CI
+
+on:
+  pull_request:
+    branches:
+      - main
+      - dev
+
+permissions:
+  contents: read
+
+jobs:
+  validate:
+    name: Validate Node 24 (merge result)
+    uses: ./.github/workflows/validate.yml
+
+  e2e:
+    name: E2E build, spin up, calculate
+    needs: validate
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check out merge result
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1
+      - name: Set up Node 24
+        uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020
+        with:
+          node-version: 24.x
+          cache: npm
+      - name: Install dependencies
+        run: npm ci
+      - name: Build application
+        run: npm run build
+      - name: Start meeet
+        env:
+          MEEET_PROVIDER_MODE: fixture
+        run: |
+          npm start > /tmp/meeet-server.log 2>&1 &
+          echo $! > /tmp/meeet-server.pid
+          for attempt in $(seq 1 90); do
+            if curl -fsS -o /dev/null http://127.0.0.1:3000/; then
+              echo "meeet is ready"
+              exit 0
+            fi
+            sleep 2
+          done
+          echo "meeet did not become ready; server log:"
+          cat /tmp/meeet-server.log
+          exit 1
+      - name: Functional calculation test
+        run: node scripts/e2e-calculation.mjs
+      - name: Stop meeet
+        if: always()
+        run: |
+          kill "$(cat /tmp/meeet-server.pid)" 2>/dev/null || true
+          pkill -f "next start" 2>/dev/null || true

--- a/.github/workflows/publish-image.yml
+++ b/.github/workflows/publish-image.yml
@@ -4,6 +4,8 @@ on:
   push:
     branches:
       - main
+      - dev
+      - "feature/**"
     tags:
       - "v*"
   workflow_dispatch:
@@ -14,26 +16,10 @@ permissions:
 jobs:
   validate:
     name: Validate on Node 24
-    runs-on: ubuntu-latest
-    steps:
-      - name: Check out source
-        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1
-      - name: Set up Node 24
-        uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020
-        with:
-          node-version: 24.x
-          cache: npm
-      - name: Install dependencies
-        run: npm ci
-      - name: Run tests
-        run: npm test
-      - name: Typecheck
-        run: npx tsc --noEmit
-      - name: Lint
-        run: npm run lint
+    uses: ./.github/workflows/validate.yml
 
   publish:
-    name: Publish runner and compiler images
+    name: Publish images
     needs: validate
     runs-on: ubuntu-latest
     permissions:
@@ -50,7 +36,7 @@ jobs:
         uses: docker/setup-buildx-action@bb05f3f5519dd87d3ba754cc423b652a5edd6d2c
 
       - name: Normalize GHCR owner
-        id: image
+        id: owner
         env:
           OWNER: ${{ github.repository_owner }}
         run: |
@@ -68,7 +54,7 @@ jobs:
         id: meta_runner
         uses: docker/metadata-action@dc802804100637a589fabce1cb79ff13a1411302
         with:
-          images: ghcr.io/${{ steps.image.outputs.owner }}/meeet
+          images: ghcr.io/${{ steps.owner.outputs.owner }}/meeet
           tags: |
             type=sha,format=long,prefix=sha-
             type=ref,event=branch
@@ -91,18 +77,23 @@ jobs:
           cache-to: type=gha,mode=max,scope=meeet-runner
           # BuildKit publishes the SLSA provenance attestation with the image.
           provenance: mode=max
+          sbom: true
 
+      # dev and feature branch pushes publish the runner only; main and
+      # release tags additionally publish the compiler.
       - name: Extract compiler image metadata
+        if: github.ref == 'refs/heads/main' || startsWith(github.ref, 'refs/tags/')
         id: meta_compiler
         uses: docker/metadata-action@dc802804100637a589fabce1cb79ff13a1411302
         with:
-          images: ghcr.io/${{ steps.image.outputs.owner }}/meeet-artifact-compiler
+          images: ghcr.io/${{ steps.owner.outputs.owner }}/meeet-artifact-compiler
           tags: |
             type=sha,format=long,prefix=sha-
             type=ref,event=branch
             type=ref,event=tag
 
       - name: Build and publish compiler
+        if: github.ref == 'refs/heads/main' || startsWith(github.ref, 'refs/tags/')
         id: build_compiler
         uses: docker/build-push-action@53b7df96c91f9c12dcc8a07bcb9ccacbed38856a
         with:
@@ -118,10 +109,11 @@ jobs:
           cache-from: type=gha,scope=meeet-compiler
           cache-to: type=gha,mode=max,scope=meeet-compiler
           provenance: mode=max
+          sbom: true
 
       - name: Write digest-pinned deployment references
         env:
-          GHCR_OWNER: ${{ steps.image.outputs.owner }}
+          GHCR_OWNER: ${{ steps.owner.outputs.owner }}
           RUNNER_DIGEST: ${{ steps.build_runner.outputs.digest }}
           COMPILER_DIGEST: ${{ steps.build_compiler.outputs.digest }}
         run: |
@@ -132,6 +124,8 @@ jobs:
             echo
             echo '```dotenv'
             echo "MEEET_IMAGE=ghcr.io/${GHCR_OWNER}/meeet@${RUNNER_DIGEST}"
-            echo "MEEET_COMPILER_IMAGE=ghcr.io/${GHCR_OWNER}/meeet-artifact-compiler@${COMPILER_DIGEST}"
+            if [ -n "${COMPILER_DIGEST}" ]; then
+              echo "MEEET_COMPILER_IMAGE=ghcr.io/${GHCR_OWNER}/meeet-artifact-compiler@${COMPILER_DIGEST}"
+            fi
             echo '```'
           } >> "$GITHUB_STEP_SUMMARY"

--- a/.github/workflows/publish-image.yml
+++ b/.github/workflows/publish-image.yml
@@ -79,10 +79,10 @@ jobs:
           provenance: mode=max
           sbom: true
 
-      # dev and feature branch pushes publish the runner only; main and
-      # release tags additionally publish the compiler.
+      # dev and main branch pushes and release tags publish the compiler;
+      # feature branch pushes publish the runner only.
       - name: Extract compiler image metadata
-        if: github.ref == 'refs/heads/main' || startsWith(github.ref, 'refs/tags/')
+        if: github.ref == 'refs/heads/main' || github.ref == 'refs/heads/dev' || startsWith(github.ref, 'refs/tags/')
         id: meta_compiler
         uses: docker/metadata-action@dc802804100637a589fabce1cb79ff13a1411302
         with:
@@ -93,7 +93,7 @@ jobs:
             type=ref,event=tag
 
       - name: Build and publish compiler
-        if: github.ref == 'refs/heads/main' || startsWith(github.ref, 'refs/tags/')
+        if: github.ref == 'refs/heads/main' || github.ref == 'refs/heads/dev' || startsWith(github.ref, 'refs/tags/')
         id: build_compiler
         uses: docker/build-push-action@53b7df96c91f9c12dcc8a07bcb9ccacbed38856a
         with:

--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -1,0 +1,30 @@
+name: Validate Node 24
+
+on:
+  workflow_call:
+
+permissions:
+  contents: read
+
+jobs:
+  validate:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check out source
+        # On pull_request events the default checkout resolves the merge ref
+        # (head merged into target), so validation proves the merged state is
+        # green; on push events it checks out the pushed commit.
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1
+      - name: Set up Node 24
+        uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020
+        with:
+          node-version: 24.x
+          cache: npm
+      - name: Install dependencies
+        run: npm ci
+      - name: Run tests
+        run: npm test
+      - name: Typecheck
+        run: npx tsc --noEmit
+      - name: Lint
+        run: npm run lint

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -23,6 +23,22 @@
 - UI, client-safe response consumption, styling, and browser tests belong to
   the visual/client migration lane; do not edit them from a server lane.
 
+## Branch and PR workflow
+
+- The supported merge path is `feature/<slug> → dev → main`; `main` is the
+  default production branch.
+- PRs into `dev` and `main` must pass Node 24 tests, typecheck, and lint on the
+  merge result (required check `Validate Node 24 (merge result) / validate`)
+  and be up-to-date with their target.
+- PRs into `dev` must additionally pass the e2e gate (required check
+  `E2E build, spin up, calculate`): a full application build, a server
+  spin-up, and one functional calculation.
+- Reviews are always performed by the oracle (code-review skill, both axes);
+  when the oracle verdict has no remaining remarks, the change may be merged
+  into `dev` without a human review. `main` promotion still requires a human
+  review.
+- `dev` and `main` are protected against force pushes and deletion.
+
 ## Engineering guardrails
 
 - Keep server-only provider credentials and schedule artifacts out of client
@@ -42,3 +58,7 @@
 - The documented Unraid production profile is operator-owned and distinct from
   the tracked Compose template; do not overwrite it or infer host-specific
   resource limits.
+- dev and feature branch publication builds the runner image only; the compiler
+  image is published only by `publish-image.yml` on pushes to `main` and
+  release tags. Production is an operator-selected digest-pinned deployment of
+  a `main`-built runner image, and no dev/feature image auto-deploys.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -30,13 +30,14 @@
 - PRs into `dev` and `main` must pass Node 24 tests, typecheck, and lint on the
   merge result (required check `Validate Node 24 (merge result) / validate`)
   and be up-to-date with their target.
-- PRs into `dev` must additionally pass the e2e gate (required check
+- PRs into `dev` and `main` must pass the e2e gate (required check
   `E2E build, spin up, calculate`): a full application build, a schedule-artifact
   compilation, a server spin-up, and one functional calculation.
-- Reviews are always performed by the oracle (code-review skill, both axes);
-  when the oracle verdict has no remaining remarks, the change may be merged
-  into `dev` without a human review. `main` promotion still requires a human
-  review.
+- Reviews are performed by the oracle (code-review skill, both axes) as an
+  advisory quality gate; the verdict never blocks merging. Branch protection
+  requires no reviews on `dev` or `main`. PRs into `dev` are created and
+  merged by the agent; `dev → main` promotion merges are performed manually
+  by the operator through the GitHub web UI, never by an agent or CLI.
 - `dev` and `main` are protected against force pushes and deletion.
 
 ## Engineering guardrails

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -31,8 +31,8 @@
   merge result (required check `Validate Node 24 (merge result) / validate`)
   and be up-to-date with their target.
 - PRs into `dev` must additionally pass the e2e gate (required check
-  `E2E build, spin up, calculate`): a full application build, a server
-  spin-up, and one functional calculation.
+  `E2E build, spin up, calculate`): a full application build, a schedule-artifact
+  compilation, a server spin-up, and one functional calculation.
 - Reviews are always performed by the oracle (code-review skill, both axes);
   when the oracle verdict has no remaining remarks, the change may be merged
   into `dev` without a human review. `main` promotion still requires a human

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -59,7 +59,8 @@
 - The documented Unraid production profile is operator-owned and distinct from
   the tracked Compose template; do not overwrite it or infer host-specific
   resource limits.
-- dev and feature branch publication builds the runner image only; the compiler
-  image is published only by `publish-image.yml` on pushes to `main` and
-  release tags. Production is an operator-selected digest-pinned deployment of
-  a `main`-built runner image, and no dev/feature image auto-deploys.
+- Feature branch publication builds the runner image only; the compiler
+  image is published by `publish-image.yml` on pushes to `main` and `dev`
+  and on release tags. Production is an operator-selected digest-pinned
+  deployment of a `main`-built runner image, and no dev/feature image
+  auto-deploys.

--- a/README.md
+++ b/README.md
@@ -58,10 +58,10 @@ force pushes and branch deletion are blocked on `dev` and `main`.
 ## Image publication
 
 Pushes to `main`, `dev`, and `feature/**` branches and release tags trigger the
-unified `publish-image.yml` workflow. `main` and release tags publish both the
-`meeet` (runner) and `meeet-artifact-compiler` (compiler) multi-platform images
-(`linux/amd64`, `linux/arm64`).
-dev and feature branch pushes publish the runner image only. Every published
+unified `publish-image.yml` workflow. `main` and `dev` pushes and release tags
+publish both the `meeet` (runner) and `meeet-artifact-compiler` (compiler)
+multi-platform images (`linux/amd64`, `linux/arm64`); feature branch pushes
+publish the runner image only. Every published
 image gets an immutable `sha-<full-sha>` tag (authoritative, matching the OCI
 revision labels) with build provenance and SBOM attestation.
 Mutable convenience tags are published only for `main` and `dev`. Feature

--- a/README.md
+++ b/README.md
@@ -46,11 +46,13 @@ service fetches the latest MVV feed and compiles (or keeps) the artifact before
 Changes flow through a single promotion path: `feature/<slug> → dev → main`.
 `main` remains the default production branch. Pull requests into `dev` and
 `main` require Node 24 test/typecheck/lint validation of the merge result (see
-[CI](#validation)); PRs into `dev` additionally require the e2e gate (build,
+[CI](#validation)); PRs into `dev` and `main` require the e2e gate (build,
 spin up, one functional calculation). Reviews are performed by the oracle
-(code-review skill); when its verdict has no remaining remarks the change may
-be merged into `dev` without a human review, while `main` promotion still
-requires a human review. Branches must be up-to-date with their target, and
+(code-review skill) as an advisory quality gate; branch protection requires no
+reviews on `dev` or `main`. PRs into `dev` are created and merged by the
+agent; `dev → main` promotion merges are performed manually by the operator
+through the GitHub web UI, never by an agent or CLI. Branches must be
+up-to-date with their target, and
 force pushes and branch deletion are blocked on `dev` and `main`.
 
 ## Image publication

--- a/README.md
+++ b/README.md
@@ -31,8 +31,8 @@ is `/mnt/user/appdata/meeet/schedule`. There are no host ports or local
 `tunnel run`, receives `TUNNEL_TOKEN`, and uses the Cloudflare dashboard
 service `http://meeet:3000`.
 
-The operator selects the runner image tag or digest and the compiler digest in
-the external `.env`. The runner and compiler GHCR packages must be public for
+The operator selects the digest-pinned runner and compiler images in the
+external `.env`. The runner and compiler GHCR packages must be public for
 unauthenticated host pulls, or the host may use a machine account with
 `read:packages`.
 
@@ -41,12 +41,35 @@ service fetches the latest MVV feed and compiles (or keeps) the artifact before
 `meeet` starts. The complete procedure is in
 [docs/application-deployment.md](docs/application-deployment.md).
 
+## Branch model
+
+Changes flow through a single promotion path: `feature/<slug> → dev → main`.
+`main` remains the default production branch. Pull requests into `dev` and
+`main` require Node 24 test/typecheck/lint validation of the merge result (see
+[CI](#validation)); PRs into `dev` additionally require the e2e gate (build,
+spin up, one functional calculation). Reviews are performed by the oracle
+(code-review skill); when its verdict has no remaining remarks the change may
+be merged into `dev` without a human review, while `main` promotion still
+requires a human review. Branches must be up-to-date with their target, and
+force pushes and branch deletion are blocked on `dev` and `main`.
+
 ## Image publication
 
-Pushes to `main` and release tags automatically build and publish both `meeet`
-(runner) and `meeet-artifact-compiler` (compiler) multi-platform images
-(`linux/amd64`, `linux/arm64`) to GHCR with immutable `sha-<full-sha>` tags and
-build provenance.
+Pushes to `main`, `dev`, and `feature/**` branches and release tags trigger the
+unified `publish-image.yml` workflow. `main` and release tags publish both the
+`meeet` (runner) and `meeet-artifact-compiler` (compiler) multi-platform images
+(`linux/amd64`, `linux/arm64`).
+dev and feature branch pushes publish the runner image only. Every published
+image gets an immutable `sha-<full-sha>` tag (authoritative, matching the OCI
+revision labels) with build provenance and SBOM attestation.
+Mutable convenience tags are published only for `main` and `dev`. Feature
+builds additionally get a branch-reference tag normalized to a valid Docker tag
+by docker/metadata-action (for example `feature/18-branch-based-development`
+becomes `feature-18-branch-based-development`); like every mutable tag it is
+never production-eligible, and the immutable `sha-<full-sha>` tag remains the
+authoritative reference. Production pairing uses the digest-pinned references
+from the workflow summary (see
+[docs/application-deployment.md](docs/application-deployment.md)).
 
 [`compose.production.yml`](compose.production.yml) remains a separate,
 checked-in hardened repository template. Its strict preflight, token-file
@@ -87,6 +110,9 @@ npm run lint
 npm run build
 git diff --check
 ```
+
+The e2e gate (`scripts/e2e-calculation.mjs`) runs against a built and started
+server in fixture provider mode and performs one functional calculation.
 
 The application boundary is Munich. Map rendering and browser fixture work are
 owned by the visual/client migration; server code must preserve the v3

--- a/README.md
+++ b/README.md
@@ -111,8 +111,11 @@ npm run build
 git diff --check
 ```
 
-The e2e gate (`scripts/e2e-calculation.mjs`) runs against a built and started
-server in fixture provider mode and performs one functional calculation.
+The e2e gate compiles the fixture GTFS into a fresh schedule artifact with a
+current validity window and time-shifted trips (`npm run schedule:compile:fixture`),
+starts the built server in fixture provider mode against that artifact, and
+performs one functional calculation at now + 5 minutes
+(`scripts/e2e-calculation.mjs`).
 
 The application boundary is Munich. Map rendering and browser fixture work are
 owned by the visual/client migration; server code must preserve the v3

--- a/docs/application-deployment.md
+++ b/docs/application-deployment.md
@@ -93,9 +93,9 @@ is the default production branch. Pushes to `main`, `dev`, and `feature/**`
 branches and release tags run the unified `publish-image.yml` workflow, which
 validates on Node 24 and builds and publishes the runner
 (`ghcr.io/tiloheidasch/meeet`) multi-platform image (`linux/amd64`,
-`linux/arm64`) on every trigger. `main` and release tags additionally publish
-the compiler (`ghcr.io/tiloheidasch/meeet-artifact-compiler`).
-dev and feature branch pushes publish the runner only. Every published image
+`linux/arm64`) on every trigger. `main` and `dev` pushes and release tags
+additionally publish the compiler (`ghcr.io/tiloheidasch/meeet-artifact-compiler`);
+feature branch pushes publish the runner only. Every published image
 carries an immutable `sha-<full-sha>` tag, OCI revision labels, provenance,
 and SBOM attestation. Mutable
 convenience tags are published only for `main` and `dev`. Feature builds

--- a/docs/application-deployment.md
+++ b/docs/application-deployment.md
@@ -23,12 +23,16 @@ The live profile is an operator-owned configuration outside this repository:
 
   ```dotenv
   TUNNEL_TOKEN=<Cloudflare tunnel token>
-  MEEET_IMAGE=ghcr.io/tiloheidasch/meeet:sha-<runner-commit>
+  MEEET_IMAGE=ghcr.io/tiloheidasch/meeet@sha256:<runner-digest>
   MEEET_COMPILER_IMAGE=ghcr.io/tiloheidasch/meeet-artifact-compiler@sha256:<publish-workflow-digest>
   MEEET_SCHEDULE_HOST_DIR=/mnt/user/appdata/meeet/schedule
   ```
 
-  The operator chooses the runner tag or digest and the compiler image in the
+  sha tags are immutable per-commit publication conveniences; the production
+  `.env` uses digest-pinned references from the workflow summary so a tag never
+  moves underneath the deployment.
+
+  The operator chooses the digest-pinned runner and compiler images in the
   external Unraid `.env`; they are not stored in this repository. The compiler
   image is selected by the operator, for example the digest-pinned value from
   the unified image publication workflow (see
@@ -78,18 +82,28 @@ so the host must be able to pull both packages. Public GHCR packages permit
 unauthenticated pulls. If the packages are private, authenticate Docker on the
 host with a machine account granted `read:packages` before pulling them.
 
-Use the runner image tag or digest and the compiler image selected by the
-operator. Changing them or the live `cloudflare/cloudflared:latest` image is an
+Use the digest-pinned runner and compiler images selected by the operator.
+Changing them or the live `cloudflare/cloudflared:latest` image is an
 external Unraid configuration change.
 
 ## Image publication and pairing
 
-Pushes to `main` and release tags run the unified `publish-image.yml` workflow,
-which validates on Node 24 and builds and publishes both the runner
-(`ghcr.io/tiloheidasch/meeet`) and compiler
-(`ghcr.io/tiloheidasch/meeet-artifact-compiler`) multi-platform images
-(`linux/amd64`, `linux/arm64`) with immutable `sha-<full-sha>` tags, OCI
-revision labels, and provenance.
+Changes flow through the promotion path `feature/<slug> → dev → main`; `main`
+is the default production branch. Pushes to `main`, `dev`, and `feature/**`
+branches and release tags run the unified `publish-image.yml` workflow, which
+validates on Node 24 and builds and publishes the runner
+(`ghcr.io/tiloheidasch/meeet`) multi-platform image (`linux/amd64`,
+`linux/arm64`) on every trigger. `main` and release tags additionally publish
+the compiler (`ghcr.io/tiloheidasch/meeet-artifact-compiler`).
+dev and feature branch pushes publish the runner only. Every published image
+carries an immutable `sha-<full-sha>` tag, OCI revision labels, provenance,
+and SBOM attestation. Mutable
+convenience tags are published only for `main` and `dev`. Feature builds
+additionally get a branch-reference tag normalized to a valid Docker tag by
+docker/metadata-action (for example `feature/18-branch-based-development`
+becomes `feature-18-branch-based-development`); like every mutable tag it is
+never production-eligible, and the immutable `sha-<full-sha>` tag remains the
+authoritative reference. Dev and feature images never auto-deploy.
 
 The workflow summary emits digest-pinned deployment references for both images
 to pair in the operator-owned runtime `.env`:
@@ -111,6 +125,18 @@ back, point `MEEET_COMPILER_IMAGE` (and `MEEET_IMAGE` if the runner revision
 should move with it) back at a previously archived digest pair and restart;
 keep the archived manifest and `.v8.bin` rollback pair from the previous
 rotation as described below.
+
+## GHCR image retention
+
+There is no automated deletion of GHCR images yet; automated cleanup is tracked
+in follow-up issue #40 and will be designed there before any deletion runs.
+Until then, retention is manual:
+
+- Keep at least the previously archived digest pair together with its archived
+  manifest and `.v8.bin` rollback pair.
+- sha-tagged images accumulate per commit and may be manually pruned by the
+  operator (GHCR UI or API).
+- Never delete the digest-pinned image currently referenced by the live `.env`.
 
 ## MVV artifact rotation
 

--- a/lib/providers/factory.ts
+++ b/lib/providers/factory.ts
@@ -20,10 +20,10 @@ export function createMeetingProviders(
 ): MeetingProviders {
   const config = readProviderConfig(env);
   if (config.mode === "fixture") {
-    return withMapConfiguration({
-      scheduledArtifact: FIXTURE_SCHEDULED_ARTIFACT,
-      scheduledAccess: FIXTURE_SCHEDULED_ACCESS_PROVIDER,
-    }, config);
+    const providers = config.scheduledArtifactPath === null
+      ? { scheduledArtifact: FIXTURE_SCHEDULED_ARTIFACT, scheduledAccess: FIXTURE_SCHEDULED_ACCESS_PROVIDER }
+      : withScheduledArtifact({ scheduledAccess: FIXTURE_SCHEDULED_ACCESS_PROVIDER }, config.scheduledArtifactPath);
+    return withMapConfiguration(providers, config);
   }
   if (config.mode === "self-hosted-routing") {
     if (!config.selfHostedRouting) throw new Error("Self-hosted routing manifest configuration is missing.");

--- a/package.json
+++ b/package.json
@@ -13,6 +13,7 @@
     "deploy:preflight": "node deploy/preflight-production.mjs",
     "start": "next start",
     "schedule:compile:mvv": "NODE_OPTIONS=--conditions=react-server tsx scripts/compile-mvv-schedule.ts",
+    "schedule:compile:fixture": "NODE_OPTIONS=--conditions=react-server tsx scripts/compile-fixture-schedule.ts",
     "lint": "eslint",
     "test": "tsx --test --import ./test/server-only-register.mjs test/*.test.ts",
     "test:e2e": "playwright test",

--- a/scripts/compile-fixture-schedule.ts
+++ b/scripts/compile-fixture-schedule.ts
@@ -1,0 +1,64 @@
+import { mkdirSync } from "node:fs";
+import { dirname, isAbsolute } from "node:path";
+
+import {
+  SCHEDULED_MVV_FEED_URL,
+  compileScheduledArtifact,
+  writeScheduledArtifact,
+} from "../lib/domain/scheduled-routing/artifact.ts";
+import { fixtureFeedFiles } from "./fixture-schedule-transform.ts";
+
+async function main(): Promise<void> {
+  const argumentsMap = parseArguments(process.argv.slice(2));
+  if (argumentsMap.help) {
+    process.stdout.write("Usage: npm run schedule:compile:fixture -- --output ABSOLUTE_JSON\n");
+    return;
+  }
+  const outputPath = argumentsMap.output;
+  if (outputPath === undefined) throw new Error("The fixture schedule compiler requires an --output path.");
+  if (!isAbsolute(outputPath)) throw new Error("The fixture schedule compiler output path must be absolute.");
+
+  const feedFiles = fixtureFeedFiles(Date.now());
+
+  const artifact = compileScheduledArtifact({
+    sourceUrl: SCHEDULED_MVV_FEED_URL,
+    rawArchiveBytes: new TextEncoder().encode(`fixture-e2e-${Date.now()}`),
+    feedFiles,
+    retrievedAt: new Date(Math.trunc(Date.now() / 1_000) * 1_000).toISOString(),
+    feedId: "fixture-scheduled-feed",
+  });
+  mkdirSync(dirname(outputPath), { recursive: true });
+  writeScheduledArtifact(outputPath, artifact);
+
+  const firstDeparture = feedFiles["stop_times.txt"].split("\n")[1]?.split(",")[2] ?? "unknown";
+  process.stdout.write(`${outputPath}\n`);
+  process.stdout.write(
+    `serviceDateRange: ${artifact.serviceDateRange.firstDate}..${artifact.serviceDateRange.lastDate}\n`,
+  );
+  process.stdout.write(`first departure: ${firstDeparture}\n`);
+}
+
+function parseArguments(argumentsList: readonly string[]): { output?: string; help?: boolean } {
+  let output: string | undefined;
+  let help = false;
+  for (let index = 0; index < argumentsList.length; index += 1) {
+    const name = argumentsList[index];
+    const value = argumentsList[index + 1];
+    if (name === "--help" || name === "-h") {
+      help = true;
+      continue;
+    }
+    if (name === "--output" && value !== undefined) {
+      output = value;
+      index += 1;
+      continue;
+    }
+    throw new Error("Usage: npm run schedule:compile:fixture -- --output ABSOLUTE_JSON");
+  }
+  return { output, help };
+}
+
+void main().catch((error: unknown) => {
+  process.stderr.write(`${error instanceof Error ? error.message : "Fixture schedule compilation failed."}\n`);
+  process.exitCode = 1;
+});

--- a/scripts/e2e-calculation.mjs
+++ b/scripts/e2e-calculation.mjs
@@ -1,0 +1,63 @@
+// E2E functional calculation gate.
+//
+// Runs against a built and started meeet server (fixture provider mode) and
+// performs one functional calculation through the public JSON endpoint.
+// Plain Node ESM, no dependencies, no TypeScript.
+
+const BASE_URL = process.env.MEEET_E2E_BASE_URL ?? "http://127.0.0.1:3000";
+
+const REQUEST = {
+  contractVersion: "meeet-meeting/v3",
+  participants: [
+    { id: "red", origin: { label: "Red", latitude: 48.1374, longitude: 11.5755 }, mode: "transit" },
+    { id: "blue", origin: { label: "Blue", latitude: 48.14, longitude: 11.57 }, mode: "transit" },
+  ],
+  tolerancePercent: 10,
+  changeTimePreset: "medium",
+  searchStartAt: "2026-08-11T08:05:00+02:00",
+};
+
+function fail(assertion, detail) {
+  console.error(`E2E FAILED: ${assertion}`);
+  if (detail !== undefined) {
+    console.error(JSON.stringify(detail, null, 2));
+  }
+  process.exit(1);
+}
+
+const response = await fetch(`${BASE_URL}/api/meeting/calculate`, {
+  method: "POST",
+  headers: { "content-type": "application/json" },
+  body: JSON.stringify(REQUEST),
+});
+
+if (response.status !== 200) {
+  fail(`HTTP status is 200 (got ${response.status})`, await response.text().catch(() => undefined));
+}
+
+const body = await response.json();
+
+if (body.contractVersion !== "meeet-meeting/v3") {
+  fail(`contractVersion is "meeet-meeting/v3"`, body.contractVersion);
+}
+if (body.status !== "ok") {
+  fail(`status is "ok"`, body.status);
+}
+if (!Array.isArray(body.participants) || body.participants.length !== 2) {
+  fail("participants is an array of length 2", body.participants);
+}
+const colors = body.participants.map((participant) => participant.color).sort();
+if (colors[0] !== "blue" || colors[1] !== "red") {
+  fail('participant colors are "red" and "blue"', colors);
+}
+if (!Array.isArray(body.stationAreas) || body.stationAreas.length === 0) {
+  fail("stationAreas is a non-empty array", body.stationAreas);
+}
+if (typeof body.metadata !== "object" || body.metadata === null) {
+  fail("metadata is an object", body.metadata);
+}
+
+console.log(
+  `E2E OK: v3 calculation returned status "ok" with ${body.stationAreas.length} station areas for red/blue participants`,
+);
+process.exit(0);

--- a/scripts/e2e-calculation.mjs
+++ b/scripts/e2e-calculation.mjs
@@ -1,7 +1,8 @@
 // E2E functional calculation gate.
 //
-// Runs against a built and started meeet server (fixture provider mode) and
-// performs one functional calculation through the public JSON endpoint.
+// Runs against a built and started meeet server (fixture provider mode with a
+// freshly compiled fixture schedule artifact) and performs one functional
+// calculation through the public JSON endpoint at now + 5 minutes.
 // Plain Node ESM, no dependencies, no TypeScript.
 
 const BASE_URL = process.env.MEEET_E2E_BASE_URL ?? "http://127.0.0.1:3000";
@@ -14,7 +15,7 @@ const REQUEST = {
   ],
   tolerancePercent: 10,
   changeTimePreset: "medium",
-  searchStartAt: "2026-08-11T08:05:00+02:00",
+  searchStartAt: new Date(Math.floor((Date.now() + 5 * 60 * 1000) / 1000) * 1000).toISOString(),
 };
 
 function fail(assertion, detail) {

--- a/scripts/fixture-schedule-transform.ts
+++ b/scripts/fixture-schedule-transform.ts
@@ -1,0 +1,79 @@
+import type { GtfsFeedFiles } from "../lib/domain/scheduled-routing/gtfs.ts";
+import { FIXTURE_SCHEDULED_GTFS_FILES } from "../lib/fixtures/scheduled-routing.ts";
+
+/** First fixture departure (fixture-a-b at 08:10) in minutes of day. */
+export const FIRST_FIXTURE_DEPARTURE_MINUTES = 490;
+
+export function currentDateRange(): { firstDate: string; lastDate: string } {
+  const today = new Date();
+  const firstDate = new Date(Date.UTC(today.getUTCFullYear(), today.getUTCMonth(), today.getUTCDate() - 1));
+  const lastDate = new Date(Date.UTC(today.getUTCFullYear(), today.getUTCMonth(), today.getUTCDate() + 1));
+  return {
+    firstDate: firstDate.toISOString().slice(0, 10),
+    lastDate: lastDate.toISOString().slice(0, 10),
+  };
+}
+
+/**
+ * Berlin wall-clock shift (minutes) that places the first fixture departure
+ * exactly ten minutes after `nowMs`, wrapping past midnight when needed.
+ */
+export function shiftMinutesFor(nowMs: number): number {
+  const nowPlusTenMinutes = nowMs + 10 * 60 * 1000;
+  const parts = new Intl.DateTimeFormat("en-GB", {
+    timeZone: "Europe/Berlin",
+    hour: "2-digit",
+    minute: "2-digit",
+    hour12: false,
+  }).formatToParts(nowPlusTenMinutes);
+  const hour = Number(parts.find((part) => part.type === "hour")?.value ?? "0");
+  const minute = Number(parts.find((part) => part.type === "minute")?.value ?? "0");
+  let shift = hour * 60 + minute - FIRST_FIXTURE_DEPARTURE_MINUTES;
+  if (shift < 0) shift += 24 * 60;
+  return shift;
+}
+
+/** The fixture feed re-dated around today and its stop times shifted to `nowMs`. */
+export function fixtureFeedFiles(nowMs: number): GtfsFeedFiles {
+  const dateRange = currentDateRange();
+  const shiftMinutes = shiftMinutesFor(nowMs);
+  return {
+    ...FIXTURE_SCHEDULED_GTFS_FILES,
+    "feed_info.txt": FIXTURE_SCHEDULED_GTFS_FILES["feed_info.txt"]
+      .replace("20260801", dateRange.firstDate.replaceAll("-", ""))
+      .replace("20260831", dateRange.lastDate.replaceAll("-", "")),
+    "calendar.txt": FIXTURE_SCHEDULED_GTFS_FILES["calendar.txt"]
+      .replace("20260801", dateRange.firstDate.replaceAll("-", ""))
+      .replace("20260831", dateRange.lastDate.replaceAll("-", "")),
+    "stop_times.txt": shiftStopTimes(FIXTURE_SCHEDULED_GTFS_FILES["stop_times.txt"], shiftMinutes),
+  };
+}
+
+function shiftStopTimes(stopTimes: string, shiftMinutes: number): string {
+  return stopTimes
+    .split("\n")
+    .map((row, index) => {
+      if (index === 0 || row.trim() === "") return row;
+      const columns = row.split(",");
+      columns[1] = shiftGtfsTime(columns[1] ?? "", shiftMinutes);
+      columns[2] = shiftGtfsTime(columns[2] ?? "", shiftMinutes);
+      return columns.join(",");
+    })
+    .join("\n");
+}
+
+function shiftGtfsTime(value: string, shiftMinutes: number): string {
+  const match = /^(\d{1,3}):(\d{2}):(\d{2})$/.exec(value);
+  if (!match) throw new Error(`Invalid GTFS time ${value}.`);
+  const hours = Number(match[1]);
+  const minutes = Number(match[2]);
+  const seconds = Number(match[3]);
+  // Mirror lib/domain/scheduled-routing/gtfs.ts gtfsTime, which rejects hours
+  // past 99 even though the fixture input is always two-digit.
+  if (hours > 99 || minutes > 59 || seconds > 59) throw new Error(`Invalid GTFS time ${value}.`);
+  const totalMinutes = hours * 60 + minutes + shiftMinutes;
+  const shiftedHours = Math.floor(totalMinutes / 60);
+  const shiftedMinutes = totalMinutes % 60;
+  if (shiftedHours > 99) throw new Error(`Shifted GTFS time ${value} exceeds the supported 99-hour range.`);
+  return `${String(shiftedHours).padStart(2, "0")}:${String(shiftedMinutes).padStart(2, "0")}:${match[3]}`;
+}

--- a/test/scheduled-routing-phase2.test.ts
+++ b/test/scheduled-routing-phase2.test.ts
@@ -25,6 +25,7 @@ import {
   FIXTURE_SCHEDULED_ACCESS_PROVIDER,
   FIXTURE_SCHEDULED_ARTIFACT,
 } from "../lib/fixtures/scheduled-routing.ts";
+import { currentDateRange, fixtureFeedFiles } from "../scripts/fixture-schedule-transform.ts";
 import { MvgScheduledAccessSeedProvider } from "../lib/providers/mvg-scheduled-access.ts";
 import { handleMeetingPost } from "../lib/domain/meeting-api.ts";
 import { fixtureProviders } from "../lib/fixtures/providers.ts";
@@ -822,4 +823,72 @@ test("configured scheduled artifact errors propagate from the provider factory",
     MEEET_SCHEDULE_ARTIFACT_PATH: "/tmp/meeet-missing-scheduled-artifact.json",
     MEEET_SCHEDULED_MIN_MEMORY_GIB: "4",
   }), ScheduleArtifactUnavailableError);
+});
+
+test("fixture mode honors MEEET_SCHEDULE_ARTIFACT_PATH and keeps the fixture access provider", async () => {
+  const directory = await mkdtemp(join(tmpdir(), "meeet-fixture-artifact-"));
+  try {
+    const dateRange = currentDateRange();
+    const feedFiles = fixtureFeedFiles(Date.now());
+    const artifact = compileScheduledArtifact({
+      sourceUrl: SCHEDULED_MVV_FEED_URL,
+      rawArchiveBytes: new TextEncoder().encode("fixture-factory-test"),
+      feedFiles,
+      retrievedAt: "2026-08-11T10:00:00Z",
+      feedId: "fixture-scheduled-feed",
+    });
+    const path = join(directory, "scheduled-artifact.json");
+    writeScheduledArtifact(path, artifact);
+
+    const providers = createMeetingProviders({
+      MEEET_PROVIDER_MODE: "fixture",
+      MEEET_SCHEDULE_ARTIFACT_PATH: path,
+    });
+    assert.equal(providers.scheduledArtifact?.feedId, "fixture-scheduled-feed");
+    assert.equal(providers.scheduledArtifact?.serviceDateRange.firstDate, dateRange.firstDate);
+    assert.equal(providers.scheduledArtifact?.serviceDateRange.lastDate, dateRange.lastDate);
+    assert.notEqual(providers.scheduledArtifact?.provenance.acquisition.feedValidFrom, "2026-08-01");
+    assert.equal(providers.scheduledAccess?.descriptor.name, "fixture-scheduled-access");
+  } finally {
+    await rm(directory, { recursive: true, force: true });
+  }
+});
+
+test("default fixture mode uses the pre-baked fixture artifact", () => {
+  const providers = createMeetingProviders({ MEEET_PROVIDER_MODE: "fixture" });
+  assert.equal(providers.scheduledArtifact?.feedId, "fixture-scheduled-feed");
+  assert.equal(providers.scheduledArtifact?.provenance.acquisition.feedValidFrom, "2026-08-01");
+  assert.equal(providers.scheduledAccess?.descriptor.name, "fixture-scheduled-access");
+});
+
+test("fixture schedule transform shifts stop times deterministically around the Berlin wall clock", () => {
+  const firstDeparture = (files: GtfsFeedFiles): string => files["stop_times.txt"].split("\n")[1]?.split(",")[2] ?? "unknown";
+  const noonFeed = fixtureFeedFiles(new Date("2026-08-18T14:00:00+02:00").getTime());
+  assert.equal(firstDeparture(noonFeed), "14:10:00");
+  const wrapFeed = fixtureFeedFiles(new Date("2026-08-18T07:00:00+02:00").getTime());
+  assert.equal(firstDeparture(wrapFeed), "31:10:00");
+  const midnightFeed = fixtureFeedFiles(new Date("2026-08-18T23:50:00+02:00").getTime());
+  assert.equal(firstDeparture(midnightFeed), "24:00:00");
+});
+
+test("fixture schedule transform re-dates the feed around today and still compiles", async () => {
+  const dateRange = currentDateRange();
+  const feedFiles = fixtureFeedFiles(new Date("2026-08-18T14:00:00+02:00").getTime());
+  const firstDate = dateRange.firstDate.replaceAll("-", "");
+  const lastDate = dateRange.lastDate.replaceAll("-", "");
+  assert.ok(feedFiles["feed_info.txt"].endsWith(`de,fixture-scheduled-2026-08,${firstDate},${lastDate}`));
+  assert.ok(feedFiles["calendar.txt"].endsWith(`1,${firstDate},${lastDate}`));
+  assert.ok(!feedFiles["feed_info.txt"].includes("20260801"));
+  assert.ok(!feedFiles["calendar.txt"].includes("20260831"));
+
+  const artifact = compileScheduledArtifact({
+    sourceUrl: SCHEDULED_MVV_FEED_URL,
+    rawArchiveBytes: new TextEncoder().encode("fixture-transform-deterministic"),
+    feedFiles,
+    retrievedAt: "2026-08-11T10:00:00Z",
+    feedId: "fixture-scheduled-feed",
+  });
+  assert.equal(artifact.feedId, "fixture-scheduled-feed");
+  assert.equal(artifact.serviceDateRange.firstDate, dateRange.firstDate);
+  assert.equal(artifact.serviceDateRange.lastDate, dateRange.lastDate);
 });

--- a/test/workflow-guard.test.ts
+++ b/test/workflow-guard.test.ts
@@ -110,14 +110,14 @@ test("documentation does not contain manual compiler dispatch instructions", () 
   }
 });
 
-test("compiler is published only on main pushes and release tags", () => {
+test("compiler is published on main and dev pushes and release tags", () => {
   const job = publishJob(publishWorkflow);
   const compilerGuard =
-    "if: github.ref == 'refs/heads/main' || startsWith(github.ref, 'refs/tags/')";
+    "if: github.ref == 'refs/heads/main' || github.ref == 'refs/heads/dev' || startsWith(github.ref, 'refs/tags/')";
   const guardMatches = job.match(new RegExp(compilerGuard.replace(/[.*+?^${}()|[\]\\]/g, "\\$&"), "g"));
   assert.ok(
     guardMatches && guardMatches.length === 2,
-    "compiler metadata and compiler build steps must both carry the main/tag guard",
+    "compiler metadata and compiler build steps must both carry the main/dev/tag guard",
   );
 
   // The runner build step must not be gated.
@@ -213,14 +213,14 @@ test("docs describe the feature/dev/main promotion path", () => {
   }
 });
 
-test("docs state dev and feature branch pushes publish the runner image only", () => {
-  assert.match(readme, /dev and feature branch pushes publish the runner image only/);
-  assert.match(readme, /`?main`? and release tags publish both/);
+test("docs state feature branch pushes publish the runner image only", () => {
+  assert.match(readme, /feature branch pushes\s+publish the runner image only/);
+  assert.match(readme, /`?main`? and `?dev`? pushes and release tags\s+publish both/);
 });
 
-test("docs state the compiler is published only on main pushes and release tags", () => {
-  assert.match(deploymentGuide, /dev and feature branch pushes publish the runner only/);
-  assert.match(readme, /`?main`? and release tags publish both/);
+test("docs state the compiler is published on main and dev pushes and release tags", () => {
+  assert.match(deploymentGuide, /feature branch pushes\s+publish the runner only/);
+  assert.match(readme, /`?main`? and `?dev`? pushes and release tags\s+publish both/);
 });
 
 test("deployment guide documents GHCR image retention with no automated deletion", () => {

--- a/test/workflow-guard.test.ts
+++ b/test/workflow-guard.test.ts
@@ -33,35 +33,44 @@ test("compiler-specific and runner-specific workflows are replaced by unified wo
   assert.equal(existsSync(resolvePath(publishWorkflowPath)), true);
 });
 
-test("unified publication triggers on push to main and tags as well as workflow_dispatch", () => {
+test("unified publication triggers on push to main, dev, and feature branches as well as tags and workflow_dispatch", () => {
   const triggers = triggerBlock(publishWorkflow);
   assert.match(triggers, /^\s*push:/m);
-  assert.match(triggers, /branches:\s*\n\s*-\s*main/m);
+  assert.match(triggers, /branches:\s*\n\s*-\s*main\s*\n\s*-\s*dev/m);
+  assert.match(triggers, /branches:\s*\n\s*-\s*main\s*\n\s*-\s*dev\s*\n\s*-\s*["']feature\/\*\*["']/m);
   assert.match(triggers, /tags:\s*\n\s*-\s*["']v\*["']/m);
   assert.match(triggers, /workflow_dispatch:/m);
 });
 
 test("validation job runs Node 24 checks before publication", () => {
+  const validateWorkflow = read(".github/workflows/validate.yml");
+  assert.match(validateWorkflow, /node-version:\s*24\.x/);
+  assert.match(validateWorkflow, /npm ci/);
+  assert.match(validateWorkflow, /npm test/);
+  assert.match(validateWorkflow, /npx tsc --noEmit/);
+  assert.match(validateWorkflow, /npm run lint/);
+
+  // Both callers reuse the shared workflow and preserve their job names.
   const beforePublish = publishWorkflow.slice(0, publishWorkflow.indexOf("  publish:"));
-  assert.match(beforePublish, /node-version:\s*24\.x/);
-  assert.match(beforePublish, /npm ci/);
-  assert.match(beforePublish, /npm test/);
-  assert.match(beforePublish, /npx tsc --noEmit/);
-  assert.match(beforePublish, /npm run lint/);
+  assert.match(beforePublish, /uses:\s*\.\/\.github\/workflows\/validate\.yml/);
+  assert.match(beforePublish, /name:\s*Validate on Node 24/);
+  const ciWorkflow = read(".github/workflows/ci.yml");
+  assert.match(ciWorkflow, /uses:\s*\.\/\.github\/workflows\/validate\.yml/);
+  assert.match(ciWorkflow, /name:\s*Validate Node 24 \(merge result\)/);
 });
 
 test("publish job builds and publishes both runner and compiler images with multi-platform and provenance", () => {
   const job = publishJob(publishWorkflow);
 
   // Runner image configuration
-  assert.match(job, /images:\s*ghcr\.io\/\${{\s*steps\.image\.outputs\.owner\s*}}\/meeet\b/);
+  assert.match(job, /images:\s*ghcr\.io\/\${{\s*steps\.owner\.outputs\.owner\s*}}\/meeet\b/);
   assert.match(job, /target:\s*runner/);
   assert.match(job, /platforms:\s*linux\/amd64,linux\/arm64/);
   assert.match(job, /cache-from:\s*type=gha,scope=meeet-runner/);
   assert.match(job, /cache-to:\s*type=gha,mode=max,scope=meeet-runner/);
 
   // Compiler image configuration
-  assert.match(job, /images:\s*ghcr\.io\/\${{\s*steps\.image\.outputs\.owner\s*}}\/meeet-artifact-compiler\b/);
+  assert.match(job, /images:\s*ghcr\.io\/\${{\s*steps\.owner\.outputs\.owner\s*}}\/meeet-artifact-compiler\b/);
   assert.match(job, /target:\s*artifact-compiler/);
   assert.match(job, /cache-from:\s*type=gha,scope=meeet-compiler/);
   assert.match(job, /cache-to:\s*type=gha,mode=max,scope=meeet-compiler/);
@@ -99,4 +108,124 @@ test("documentation does not contain manual compiler dispatch instructions", () 
     assert.doesNotMatch(doc, dispatchPattern);
     assert.doesNotMatch(doc, /publish-runner\.yml/);
   }
+});
+
+test("compiler is published only on main pushes and release tags", () => {
+  const job = publishJob(publishWorkflow);
+  const compilerGuard =
+    "if: github.ref == 'refs/heads/main' || startsWith(github.ref, 'refs/tags/')";
+  const guardMatches = job.match(new RegExp(compilerGuard.replace(/[.*+?^${}()|[\]\\]/g, "\\$&"), "g"));
+  assert.ok(
+    guardMatches && guardMatches.length === 2,
+    "compiler metadata and compiler build steps must both carry the main/tag guard",
+  );
+
+  // The runner build step must not be gated.
+  const runnerSection = job.slice(
+    job.indexOf("Build and publish runner"),
+    job.indexOf("Extract compiler image metadata"),
+  );
+  assert.doesNotMatch(runnerSection, /^\s*if:/m);
+});
+
+test("tags are produced by docker/metadata-action without raw ref interpolation", () => {
+  const metadataMatches = publishWorkflow.match(/uses:\s*docker\/metadata-action/g);
+  assert.ok(
+    metadataMatches && metadataMatches.length === 2,
+    "both runner and compiler must use docker/metadata-action",
+  );
+  assert.match(publishWorkflow, /type=sha,format=long,prefix=sha-/);
+  assert.match(publishWorkflow, /type=ref,event=branch/);
+  assert.match(publishWorkflow, /type=ref,event=tag/);
+  assert.doesNotMatch(publishWorkflow, /\$\{\{\s*github\.ref(?:_name)?\s*\}\}/);
+});
+
+test("runner and compiler images carry SBOM attestation and OCI revision labels", () => {
+  const sbomMatches = publishWorkflow.match(/sbom:\s*true/g);
+  assert.ok(
+    sbomMatches && sbomMatches.length === 2,
+    "both runner and compiler builds must emit an SBOM attestation",
+  );
+  assert.match(publishWorkflow, /labels:\s*\$\{\{\s*steps\.meta_runner\.outputs\.labels\s*\}\}/);
+  assert.match(publishWorkflow, /labels:\s*\$\{\{\s*steps\.meta_compiler\.outputs\.labels\s*\}\}/);
+});
+
+test("PR CI validates the merge result with least privilege", () => {
+  const ciWorkflow = read(".github/workflows/ci.yml");
+  const ciTriggers = triggerBlock(ciWorkflow);
+  assert.match(ciTriggers, /^\s*pull_request:/m);
+  assert.match(ciTriggers, /branches:\s*\n\s*-\s*main\s*\n\s*-\s*dev/m);
+  assert.doesNotMatch(ciWorkflow, /pull_request_target/);
+  assert.match(ciWorkflow, /^permissions:\n  contents:\s*read/m);
+  assert.doesNotMatch(ciWorkflow, /packages:\s*write/);
+  assert.doesNotMatch(ciWorkflow, /id-token:/);
+  assert.doesNotMatch(ciWorkflow, /attestations:/);
+  assert.doesNotMatch(ciWorkflow, /secrets\./);
+  assert.match(ciWorkflow, /uses:\s*\.\/\.github\/workflows\/validate\.yml/);
+  assert.match(ciWorkflow, /name:\s*Validate Node 24 \(merge result\)/);
+
+  // The shared validation workflow itself stays least privilege.
+  const validateWorkflow = read(".github/workflows/validate.yml");
+  assert.match(validateWorkflow, /^permissions:\n  contents:\s*read/m);
+  assert.doesNotMatch(validateWorkflow, /secrets\./);
+  assert.doesNotMatch(validateWorkflow, /packages:/);
+  assert.doesNotMatch(validateWorkflow, /id-token:/);
+  assert.doesNotMatch(validateWorkflow, /attestations:/);
+});
+
+test("branch protection check context is pinned by the guard tests", () => {
+  // The required check context on dev/main is "<caller job name> / <reusable
+  // job id>", i.e. "Validate Node 24 (merge result) / validate"; renaming
+  // either breaks the merge gate.
+  const validateWorkflow = read(".github/workflows/validate.yml");
+  assert.match(validateWorkflow, /^jobs:\n  validate:/m);
+  const ciWorkflow = read(".github/workflows/ci.yml");
+  assert.match(ciWorkflow, /name:\s*Validate Node 24 \(merge result\)/);
+});
+
+test("PR CI includes an e2e gate that builds, starts meeet, and runs a functional calculation", () => {
+  const ciWorkflow = read(".github/workflows/ci.yml");
+  assert.match(ciWorkflow, /name:\s*E2E build, spin up, calculate/);
+  assert.match(ciWorkflow, /npm run build/);
+  assert.match(ciWorkflow, /npm start/);
+  assert.match(ciWorkflow, /MEEET_PROVIDER_MODE:\s*fixture/);
+  assert.match(ciWorkflow, /node scripts\/e2e-calculation\.mjs/);
+  assert.match(ciWorkflow, /needs:\s*validate/);
+
+  const e2eScript = read("scripts/e2e-calculation.mjs");
+  assert.match(e2eScript, /\/api\/meeting\/calculate/);
+  assert.match(e2eScript, /meeet-meeting\/v3/);
+  assert.match(e2eScript, /"ok"/);
+  assert.match(e2eScript, /participants\.length/);
+  assert.match(e2eScript, /"red"/);
+  assert.match(e2eScript, /"blue"/);
+  assert.match(e2eScript, /stationAreas/);
+});
+
+test("docs describe the feature/dev/main promotion path", () => {
+  const promotionPath = "feature/<slug> → dev → main";
+  for (const doc of [agentsGuide, readme, deploymentGuide]) {
+    assert.match(doc, new RegExp(promotionPath.replace(/[.*+?^${}()|[\]\\]/g, "\\$&")));
+  }
+});
+
+test("docs state dev and feature branch pushes publish the runner image only", () => {
+  assert.match(readme, /dev and feature branch pushes publish the runner image only/);
+  assert.match(readme, /`?main`? and release tags publish both/);
+});
+
+test("docs state the compiler is published only on main pushes and release tags", () => {
+  assert.match(deploymentGuide, /dev and feature branch pushes publish the runner only/);
+  assert.match(readme, /`?main`? and release tags publish both/);
+});
+
+test("deployment guide documents GHCR image retention with no automated deletion", () => {
+  const retentionSection = deploymentGuide.slice(deploymentGuide.indexOf("## GHCR image retention"));
+  assert.match(retentionSection, /GHCR image retention/i);
+  assert.match(retentionSection, /no automated deletion/i);
+  assert.match(retentionSection, /#40/);
+});
+
+test("deployment guide runtime .env sample uses digest-pinned runner image", () => {
+  assert.match(deploymentGuide, /MEEET_IMAGE=ghcr\.io\/tiloheidasch\/meeet@sha256:/);
 });

--- a/test/workflow-guard.test.ts
+++ b/test/workflow-guard.test.ts
@@ -187,6 +187,8 @@ test("PR CI includes an e2e gate that builds, starts meeet, and runs a functiona
   const ciWorkflow = read(".github/workflows/ci.yml");
   assert.match(ciWorkflow, /name:\s*E2E build, spin up, calculate/);
   assert.match(ciWorkflow, /npm run build/);
+  assert.match(ciWorkflow, /schedule:compile:fixture/);
+  assert.match(ciWorkflow, /MEEET_SCHEDULE_ARTIFACT_PATH:\s*\/tmp\/mvv-scheduled-artifact\.json/);
   assert.match(ciWorkflow, /npm start/);
   assert.match(ciWorkflow, /MEEET_PROVIDER_MODE:\s*fixture/);
   assert.match(ciWorkflow, /node scripts\/e2e-calculation\.mjs/);
@@ -200,6 +202,8 @@ test("PR CI includes an e2e gate that builds, starts meeet, and runs a functiona
   assert.match(e2eScript, /"red"/);
   assert.match(e2eScript, /"blue"/);
   assert.match(e2eScript, /stationAreas/);
+  assert.match(e2eScript, /Date\.now/);
+  assert.match(e2eScript, /5 \* 60 \* 1000/);
 });
 
 test("docs describe the feature/dev/main promotion path", () => {


### PR DESCRIPTION
## Promotion: dev → main

Promotes two oracle-reviewed changes from `dev` (merged via #41 and #44, clean verdicts on both axes — no remaining remarks).

## 1. Branch-based development + GHCR image publication (#18, via #41)

- **Branch model**: `feature/<slug> → dev → main` documented in AGENTS.md/README/deployment guide; `main` stays default; `dev` created from the production baseline.
- **PR CI** (`ci.yml` + reusable `validate.yml`): fork-safe, least-privilege, Node 24 test/typecheck/lint on the merge result.
- **E2E gate**: required check `E2E build, spin up, calculate` on `dev` and `main`.
- **Publication** (`publish-image.yml`): runner on `main`/`dev`/`feature/**` pushes + release tags; compiler only on `main`/tags; immutable `sha-<full-sha>` tags, provenance + SBOM, digest-only docs.
- **Process**: oracle review (both axes) gates dev merges; `main` promotion requires a human review (this PR).
- **Protection**: `dev`/`main` strict checks, no force push/deletion, `enforce_admins`; `main` requires 1 review.

## 2. E2E gate compiles the schedule artifact, calculates at now + 5 min (#18, via #44)

- The gate now compiles a fresh hermetic fixture schedule artifact (`scripts/compile-fixture-schedule.ts` + shared `scripts/fixture-schedule-transform.ts`): dates re-based to today−1..today+1, stop times shifted to now+10 min Berlin wall clock (midnight/pre-08:10 wrap, GTFS >24h times, consumer-aligned validation).
- `searchStartAt` = whole-second now + 5 min (no fixed date — immune to schedule evolution).
- `lib/providers/factory.ts`: fixture mode honors `MEEET_SCHEDULE_ARTIFACT_PATH`, keeps the fixture access provider; default unchanged.
- Guard tests pin the compile step, artifact-path wiring, and now+5min; deterministic shift-math unit tests.

## Verification

`npm test` (241 pass, 0 fail), `npx tsc --noEmit`, `npm run lint` (0 errors), `git diff --check`, local e2e proof (`E2E OK`, current serviceDateRange), CI green incl. e2e gate on the merge ref. Oracle-reviewed on both axes — clean.