### PR TITLE
feat(ci): e2e compiles the schedule artifact and calculates at now + 5 min (#18)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -30,9 +30,12 @@ jobs:
         run: npm ci
       - name: Build application
         run: npm run build
+      - name: Compile fixture schedule artifact
+        run: npm run schedule:compile:fixture -- --output /tmp/mvv-scheduled-artifact.json
       - name: Start meeet
         env:
           MEEET_PROVIDER_MODE: fixture
+          MEEET_SCHEDULE_ARTIFACT_PATH: /tmp/mvv-scheduled-artifact.json
         run: |
           npm start > /tmp/meeet-server.log 2>&1 &
           echo $! > /tmp/meeet-server.pid

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -31,8 +31,8 @@
   merge result (required check `Validate Node 24 (merge result) / validate`)
   and be up-to-date with their target.
 - PRs into `dev` must additionally pass the e2e gate (required check
-  `E2E build, spin up, calculate`): a full application build, a server
-  spin-up, and one functional calculation.
+  `E2E build, spin up, calculate`): a full application build, a schedule-artifact
+  compilation, a server spin-up, and one functional calculation.
 - Reviews are always performed by the oracle (code-review skill, both axes);
   when the oracle verdict has no remaining remarks, the change may be merged
   into `dev` without a human review. `main` promotion still requires a human

--- a/README.md
+++ b/README.md
@@ -111,8 +111,11 @@ npm run build
 git diff --check
 ```
 
-The e2e gate (`scripts/e2e-calculation.mjs`) runs against a built and started
-server in fixture provider mode and performs one functional calculation.
+The e2e gate compiles the fixture GTFS into a fresh schedule artifact with a
+current validity window and time-shifted trips (`npm run schedule:compile:fixture`),
+starts the built server in fixture provider mode against that artifact, and
+performs one functional calculation at now + 5 minutes
+(`scripts/e2e-calculation.mjs`).
 
 The application boundary is Munich. Map rendering and browser fixture work are
 owned by the visual/client migration; server code must preserve the v3

--- a/lib/providers/factory.ts
+++ b/lib/providers/factory.ts
@@ -20,10 +20,10 @@ export function createMeetingProviders(
 ): MeetingProviders {
   const config = readProviderConfig(env);
   if (config.mode === "fixture") {
-    return withMapConfiguration({
-      scheduledArtifact: FIXTURE_SCHEDULED_ARTIFACT,
-      scheduledAccess: FIXTURE_SCHEDULED_ACCESS_PROVIDER,
-    }, config);
+    const providers = config.scheduledArtifactPath === null
+      ? { scheduledArtifact: FIXTURE_SCHEDULED_ARTIFACT, scheduledAccess: FIXTURE_SCHEDULED_ACCESS_PROVIDER }
+      : withScheduledArtifact({ scheduledAccess: FIXTURE_SCHEDULED_ACCESS_PROVIDER }, config.scheduledArtifactPath);
+    return withMapConfiguration(providers, config);
   }
   if (config.mode === "self-hosted-routing") {
     if (!config.selfHostedRouting) throw new Error("Self-hosted routing manifest configuration is missing.");

--- a/package.json
+++ b/package.json
@@ -13,6 +13,7 @@
     "deploy:preflight": "node deploy/preflight-production.mjs",
     "start": "next start",
     "schedule:compile:mvv": "NODE_OPTIONS=--conditions=react-server tsx scripts/compile-mvv-schedule.ts",
+    "schedule:compile:fixture": "NODE_OPTIONS=--conditions=react-server tsx scripts/compile-fixture-schedule.ts",
     "lint": "eslint",
     "test": "tsx --test --import ./test/server-only-register.mjs test/*.test.ts",
     "test:e2e": "playwright test",

--- a/scripts/compile-fixture-schedule.ts
+++ b/scripts/compile-fixture-schedule.ts
@@ -1,0 +1,125 @@
+import { mkdirSync } from "node:fs";
+import { dirname, isAbsolute } from "node:path";
+
+import {
+  SCHEDULED_MVV_FEED_URL,
+  compileScheduledArtifact,
+  writeScheduledArtifact,
+} from "../lib/domain/scheduled-routing/artifact.ts";
+import { FIXTURE_SCHEDULED_GTFS_FILES } from "../lib/fixtures/scheduled-routing.ts";
+
+/** First fixture departure (fixture-a-b at 08:10) in minutes of day. */
+const FIRST_FIXTURE_DEPARTURE_MINUTES = 490;
+
+async function main(): Promise<void> {
+  const argumentsMap = parseArguments(process.argv.slice(2));
+  if (argumentsMap.help) {
+    process.stdout.write("Usage: npm run schedule:compile:fixture -- --output ABSOLUTE_JSON\n");
+    return;
+  }
+  const outputPath = argumentsMap.output;
+  if (outputPath === undefined) throw new Error("The fixture schedule compiler requires an --output path.");
+  if (!isAbsolute(outputPath)) throw new Error("The fixture schedule compiler output path must be absolute.");
+
+  const dateRange = currentDateRange();
+  const shiftMinutes = fixtureShiftMinutes();
+  const feedFiles = {
+    ...FIXTURE_SCHEDULED_GTFS_FILES,
+    "feed_info.txt": FIXTURE_SCHEDULED_GTFS_FILES["feed_info.txt"]
+      .replace("20260801", dateRange.firstDate.replaceAll("-", ""))
+      .replace("20260831", dateRange.lastDate.replaceAll("-", "")),
+    "calendar.txt": FIXTURE_SCHEDULED_GTFS_FILES["calendar.txt"]
+      .replace("20260801", dateRange.firstDate.replaceAll("-", ""))
+      .replace("20260831", dateRange.lastDate.replaceAll("-", "")),
+    "stop_times.txt": shiftStopTimes(FIXTURE_SCHEDULED_GTFS_FILES["stop_times.txt"], shiftMinutes),
+  };
+
+  const artifact = compileScheduledArtifact({
+    sourceUrl: SCHEDULED_MVV_FEED_URL,
+    rawArchiveBytes: new TextEncoder().encode(`fixture-e2e-${Date.now()}`),
+    feedFiles,
+    retrievedAt: new Date(Math.trunc(Date.now() / 1_000) * 1_000).toISOString(),
+    feedId: "fixture-scheduled-feed",
+  });
+  mkdirSync(dirname(outputPath), { recursive: true });
+  writeScheduledArtifact(outputPath, artifact);
+
+  const firstDeparture = feedFiles["stop_times.txt"].split("\n")[1]?.split(",")[2] ?? "unknown";
+  process.stdout.write(`${outputPath}\n`);
+  process.stdout.write(
+    `serviceDateRange: ${artifact.serviceDateRange.firstDate}..${artifact.serviceDateRange.lastDate}\n`,
+  );
+  process.stdout.write(`first departure: ${firstDeparture}\n`);
+}
+
+function parseArguments(argumentsList: readonly string[]): { output?: string; help?: boolean } {
+  let output: string | undefined;
+  let help = false;
+  for (let index = 0; index < argumentsList.length; index += 1) {
+    const name = argumentsList[index];
+    const value = argumentsList[index + 1];
+    if (name === "--help" || name === "-h") {
+      help = true;
+      continue;
+    }
+    if (name === "--output" && value !== undefined) {
+      output = value;
+      index += 1;
+      continue;
+    }
+    throw new Error("Usage: npm run schedule:compile:fixture -- --output ABSOLUTE_JSON");
+  }
+  return { output, help };
+}
+
+function currentDateRange(): { firstDate: string; lastDate: string } {
+  const today = new Date();
+  const firstDate = new Date(Date.UTC(today.getUTCFullYear(), today.getUTCMonth(), today.getUTCDate() - 1));
+  const lastDate = new Date(Date.UTC(today.getUTCFullYear(), today.getUTCMonth(), today.getUTCDate() + 1));
+  return {
+    firstDate: firstDate.toISOString().slice(0, 10),
+    lastDate: lastDate.toISOString().slice(0, 10),
+  };
+}
+
+function fixtureShiftMinutes(): number {
+  const nowPlusTenMinutes = Date.now() + 10 * 60 * 1000;
+  const parts = new Intl.DateTimeFormat("en-GB", {
+    timeZone: "Europe/Berlin",
+    hour: "2-digit",
+    minute: "2-digit",
+    hour12: false,
+  }).formatToParts(nowPlusTenMinutes);
+  const hour = Number(parts.find((part) => part.type === "hour")?.value ?? "0");
+  const minute = Number(parts.find((part) => part.type === "minute")?.value ?? "0");
+  let shift = hour * 60 + minute - FIRST_FIXTURE_DEPARTURE_MINUTES;
+  if (shift < 0) shift += 24 * 60;
+  return shift;
+}
+
+function shiftStopTimes(stopTimes: string, shiftMinutes: number): string {
+  return stopTimes
+    .split("\n")
+    .map((row, index) => {
+      if (index === 0 || row.trim() === "") return row;
+      const columns = row.split(",");
+      columns[1] = shiftGtfsTime(columns[1] ?? "", shiftMinutes);
+      columns[2] = shiftGtfsTime(columns[2] ?? "", shiftMinutes);
+      return columns.join(",");
+    })
+    .join("\n");
+}
+
+function shiftGtfsTime(value: string, shiftMinutes: number): string {
+  const match = /^(\d{1,3}):(\d{2}):(\d{2})$/.exec(value);
+  if (!match) throw new Error(`Invalid GTFS time ${value}.`);
+  const totalMinutes = Number(match[1]) * 60 + Number(match[2]) + shiftMinutes;
+  const hours = Math.floor(totalMinutes / 60);
+  const minutes = totalMinutes % 60;
+  return `${String(hours).padStart(2, "0")}:${String(minutes).padStart(2, "0")}:${match[3]}`;
+}
+
+void main().catch((error: unknown) => {
+  process.stderr.write(`${error instanceof Error ? error.message : "Fixture schedule compilation failed."}\n`);
+  process.exitCode = 1;
+});

--- a/scripts/compile-fixture-schedule.ts
+++ b/scripts/compile-fixture-schedule.ts
@@ -6,10 +6,7 @@ import {
   compileScheduledArtifact,
   writeScheduledArtifact,
 } from "../lib/domain/scheduled-routing/artifact.ts";
-import { FIXTURE_SCHEDULED_GTFS_FILES } from "../lib/fixtures/scheduled-routing.ts";
-
-/** First fixture departure (fixture-a-b at 08:10) in minutes of day. */
-const FIRST_FIXTURE_DEPARTURE_MINUTES = 490;
+import { fixtureFeedFiles } from "./fixture-schedule-transform.ts";
 
 async function main(): Promise<void> {
   const argumentsMap = parseArguments(process.argv.slice(2));
@@ -21,18 +18,7 @@ async function main(): Promise<void> {
   if (outputPath === undefined) throw new Error("The fixture schedule compiler requires an --output path.");
   if (!isAbsolute(outputPath)) throw new Error("The fixture schedule compiler output path must be absolute.");
 
-  const dateRange = currentDateRange();
-  const shiftMinutes = fixtureShiftMinutes();
-  const feedFiles = {
-    ...FIXTURE_SCHEDULED_GTFS_FILES,
-    "feed_info.txt": FIXTURE_SCHEDULED_GTFS_FILES["feed_info.txt"]
-      .replace("20260801", dateRange.firstDate.replaceAll("-", ""))
-      .replace("20260831", dateRange.lastDate.replaceAll("-", "")),
-    "calendar.txt": FIXTURE_SCHEDULED_GTFS_FILES["calendar.txt"]
-      .replace("20260801", dateRange.firstDate.replaceAll("-", ""))
-      .replace("20260831", dateRange.lastDate.replaceAll("-", "")),
-    "stop_times.txt": shiftStopTimes(FIXTURE_SCHEDULED_GTFS_FILES["stop_times.txt"], shiftMinutes),
-  };
+  const feedFiles = fixtureFeedFiles(Date.now());
 
   const artifact = compileScheduledArtifact({
     sourceUrl: SCHEDULED_MVV_FEED_URL,
@@ -70,53 +56,6 @@ function parseArguments(argumentsList: readonly string[]): { output?: string; he
     throw new Error("Usage: npm run schedule:compile:fixture -- --output ABSOLUTE_JSON");
   }
   return { output, help };
-}
-
-function currentDateRange(): { firstDate: string; lastDate: string } {
-  const today = new Date();
-  const firstDate = new Date(Date.UTC(today.getUTCFullYear(), today.getUTCMonth(), today.getUTCDate() - 1));
-  const lastDate = new Date(Date.UTC(today.getUTCFullYear(), today.getUTCMonth(), today.getUTCDate() + 1));
-  return {
-    firstDate: firstDate.toISOString().slice(0, 10),
-    lastDate: lastDate.toISOString().slice(0, 10),
-  };
-}
-
-function fixtureShiftMinutes(): number {
-  const nowPlusTenMinutes = Date.now() + 10 * 60 * 1000;
-  const parts = new Intl.DateTimeFormat("en-GB", {
-    timeZone: "Europe/Berlin",
-    hour: "2-digit",
-    minute: "2-digit",
-    hour12: false,
-  }).formatToParts(nowPlusTenMinutes);
-  const hour = Number(parts.find((part) => part.type === "hour")?.value ?? "0");
-  const minute = Number(parts.find((part) => part.type === "minute")?.value ?? "0");
-  let shift = hour * 60 + minute - FIRST_FIXTURE_DEPARTURE_MINUTES;
-  if (shift < 0) shift += 24 * 60;
-  return shift;
-}
-
-function shiftStopTimes(stopTimes: string, shiftMinutes: number): string {
-  return stopTimes
-    .split("\n")
-    .map((row, index) => {
-      if (index === 0 || row.trim() === "") return row;
-      const columns = row.split(",");
-      columns[1] = shiftGtfsTime(columns[1] ?? "", shiftMinutes);
-      columns[2] = shiftGtfsTime(columns[2] ?? "", shiftMinutes);
-      return columns.join(",");
-    })
-    .join("\n");
-}
-
-function shiftGtfsTime(value: string, shiftMinutes: number): string {
-  const match = /^(\d{1,3}):(\d{2}):(\d{2})$/.exec(value);
-  if (!match) throw new Error(`Invalid GTFS time ${value}.`);
-  const totalMinutes = Number(match[1]) * 60 + Number(match[2]) + shiftMinutes;
-  const hours = Math.floor(totalMinutes / 60);
-  const minutes = totalMinutes % 60;
-  return `${String(hours).padStart(2, "0")}:${String(minutes).padStart(2, "0")}:${match[3]}`;
 }
 
 void main().catch((error: unknown) => {

--- a/scripts/e2e-calculation.mjs
+++ b/scripts/e2e-calculation.mjs
@@ -1,7 +1,8 @@
 // E2E functional calculation gate.
 //
-// Runs against a built and started meeet server (fixture provider mode) and
-// performs one functional calculation through the public JSON endpoint.
+// Runs against a built and started meeet server (fixture provider mode with a
+// freshly compiled fixture schedule artifact) and performs one functional
+// calculation through the public JSON endpoint at now + 5 minutes.
 // Plain Node ESM, no dependencies, no TypeScript.
 
 const BASE_URL = process.env.MEEET_E2E_BASE_URL ?? "http://127.0.0.1:3000";
@@ -14,7 +15,7 @@ const REQUEST = {
   ],
   tolerancePercent: 10,
   changeTimePreset: "medium",
-  searchStartAt: "2026-08-11T08:05:00+02:00",
+  searchStartAt: new Date(Math.floor((Date.now() + 5 * 60 * 1000) / 1000) * 1000).toISOString(),
 };
 
 function fail(assertion, detail) {

--- a/scripts/fixture-schedule-transform.ts
+++ b/scripts/fixture-schedule-transform.ts
@@ -1,0 +1,79 @@
+import type { GtfsFeedFiles } from "../lib/domain/scheduled-routing/gtfs.ts";
+import { FIXTURE_SCHEDULED_GTFS_FILES } from "../lib/fixtures/scheduled-routing.ts";
+
+/** First fixture departure (fixture-a-b at 08:10) in minutes of day. */
+export const FIRST_FIXTURE_DEPARTURE_MINUTES = 490;
+
+export function currentDateRange(): { firstDate: string; lastDate: string } {
+  const today = new Date();
+  const firstDate = new Date(Date.UTC(today.getUTCFullYear(), today.getUTCMonth(), today.getUTCDate() - 1));
+  const lastDate = new Date(Date.UTC(today.getUTCFullYear(), today.getUTCMonth(), today.getUTCDate() + 1));
+  return {
+    firstDate: firstDate.toISOString().slice(0, 10),
+    lastDate: lastDate.toISOString().slice(0, 10),
+  };
+}
+
+/**
+ * Berlin wall-clock shift (minutes) that places the first fixture departure
+ * exactly ten minutes after `nowMs`, wrapping past midnight when needed.
+ */
+export function shiftMinutesFor(nowMs: number): number {
+  const nowPlusTenMinutes = nowMs + 10 * 60 * 1000;
+  const parts = new Intl.DateTimeFormat("en-GB", {
+    timeZone: "Europe/Berlin",
+    hour: "2-digit",
+    minute: "2-digit",
+    hour12: false,
+  }).formatToParts(nowPlusTenMinutes);
+  const hour = Number(parts.find((part) => part.type === "hour")?.value ?? "0");
+  const minute = Number(parts.find((part) => part.type === "minute")?.value ?? "0");
+  let shift = hour * 60 + minute - FIRST_FIXTURE_DEPARTURE_MINUTES;
+  if (shift < 0) shift += 24 * 60;
+  return shift;
+}
+
+/** The fixture feed re-dated around today and its stop times shifted to `nowMs`. */
+export function fixtureFeedFiles(nowMs: number): GtfsFeedFiles {
+  const dateRange = currentDateRange();
+  const shiftMinutes = shiftMinutesFor(nowMs);
+  return {
+    ...FIXTURE_SCHEDULED_GTFS_FILES,
+    "feed_info.txt": FIXTURE_SCHEDULED_GTFS_FILES["feed_info.txt"]
+      .replace("20260801", dateRange.firstDate.replaceAll("-", ""))
+      .replace("20260831", dateRange.lastDate.replaceAll("-", "")),
+    "calendar.txt": FIXTURE_SCHEDULED_GTFS_FILES["calendar.txt"]
+      .replace("20260801", dateRange.firstDate.replaceAll("-", ""))
+      .replace("20260831", dateRange.lastDate.replaceAll("-", "")),
+    "stop_times.txt": shiftStopTimes(FIXTURE_SCHEDULED_GTFS_FILES["stop_times.txt"], shiftMinutes),
+  };
+}
+
+function shiftStopTimes(stopTimes: string, shiftMinutes: number): string {
+  return stopTimes
+    .split("\n")
+    .map((row, index) => {
+      if (index === 0 || row.trim() === "") return row;
+      const columns = row.split(",");
+      columns[1] = shiftGtfsTime(columns[1] ?? "", shiftMinutes);
+      columns[2] = shiftGtfsTime(columns[2] ?? "", shiftMinutes);
+      return columns.join(",");
+    })
+    .join("\n");
+}
+
+function shiftGtfsTime(value: string, shiftMinutes: number): string {
+  const match = /^(\d{1,3}):(\d{2}):(\d{2})$/.exec(value);
+  if (!match) throw new Error(`Invalid GTFS time ${value}.`);
+  const hours = Number(match[1]);
+  const minutes = Number(match[2]);
+  const seconds = Number(match[3]);
+  // Mirror lib/domain/scheduled-routing/gtfs.ts gtfsTime, which rejects hours
+  // past 99 even though the fixture input is always two-digit.
+  if (hours > 99 || minutes > 59 || seconds > 59) throw new Error(`Invalid GTFS time ${value}.`);
+  const totalMinutes = hours * 60 + minutes + shiftMinutes;
+  const shiftedHours = Math.floor(totalMinutes / 60);
+  const shiftedMinutes = totalMinutes % 60;
+  if (shiftedHours > 99) throw new Error(`Shifted GTFS time ${value} exceeds the supported 99-hour range.`);
+  return `${String(shiftedHours).padStart(2, "0")}:${String(shiftedMinutes).padStart(2, "0")}:${match[3]}`;
+}

--- a/test/scheduled-routing-phase2.test.ts
+++ b/test/scheduled-routing-phase2.test.ts
@@ -24,8 +24,8 @@ import {
 import {
   FIXTURE_SCHEDULED_ACCESS_PROVIDER,
   FIXTURE_SCHEDULED_ARTIFACT,
-  FIXTURE_SCHEDULED_GTFS_FILES,
 } from "../lib/fixtures/scheduled-routing.ts";
+import { currentDateRange, fixtureFeedFiles } from "../scripts/fixture-schedule-transform.ts";
 import { MvgScheduledAccessSeedProvider } from "../lib/providers/mvg-scheduled-access.ts";
 import { handleMeetingPost } from "../lib/domain/meeting-api.ts";
 import { fixtureProviders } from "../lib/fixtures/providers.ts";
@@ -829,15 +829,7 @@ test("fixture mode honors MEEET_SCHEDULE_ARTIFACT_PATH and keeps the fixture acc
   const directory = await mkdtemp(join(tmpdir(), "meeet-fixture-artifact-"));
   try {
     const dateRange = currentDateRange();
-    const feedFiles = {
-      ...FIXTURE_SCHEDULED_GTFS_FILES,
-      "feed_info.txt": FIXTURE_SCHEDULED_GTFS_FILES["feed_info.txt"]
-        .replace("20260801", dateRange.firstDate.replaceAll("-", ""))
-        .replace("20260831", dateRange.lastDate.replaceAll("-", "")),
-      "calendar.txt": FIXTURE_SCHEDULED_GTFS_FILES["calendar.txt"]
-        .replace("20260801", dateRange.firstDate.replaceAll("-", ""))
-        .replace("20260831", dateRange.lastDate.replaceAll("-", "")),
-    };
+    const feedFiles = fixtureFeedFiles(Date.now());
     const artifact = compileScheduledArtifact({
       sourceUrl: SCHEDULED_MVV_FEED_URL,
       rawArchiveBytes: new TextEncoder().encode("fixture-factory-test"),
@@ -869,12 +861,34 @@ test("default fixture mode uses the pre-baked fixture artifact", () => {
   assert.equal(providers.scheduledAccess?.descriptor.name, "fixture-scheduled-access");
 });
 
-function currentDateRange(): { firstDate: string; lastDate: string } {
-  const today = new Date();
-  const firstDate = new Date(Date.UTC(today.getUTCFullYear(), today.getUTCMonth(), today.getUTCDate() - 1));
-  const lastDate = new Date(Date.UTC(today.getUTCFullYear(), today.getUTCMonth(), today.getUTCDate() + 1));
-  return {
-    firstDate: firstDate.toISOString().slice(0, 10),
-    lastDate: lastDate.toISOString().slice(0, 10),
-  };
-}
+test("fixture schedule transform shifts stop times deterministically around the Berlin wall clock", () => {
+  const firstDeparture = (files: GtfsFeedFiles): string => files["stop_times.txt"].split("\n")[1]?.split(",")[2] ?? "unknown";
+  const noonFeed = fixtureFeedFiles(new Date("2026-08-18T14:00:00+02:00").getTime());
+  assert.equal(firstDeparture(noonFeed), "14:10:00");
+  const wrapFeed = fixtureFeedFiles(new Date("2026-08-18T07:00:00+02:00").getTime());
+  assert.equal(firstDeparture(wrapFeed), "31:10:00");
+  const midnightFeed = fixtureFeedFiles(new Date("2026-08-18T23:50:00+02:00").getTime());
+  assert.equal(firstDeparture(midnightFeed), "24:00:00");
+});
+
+test("fixture schedule transform re-dates the feed around today and still compiles", async () => {
+  const dateRange = currentDateRange();
+  const feedFiles = fixtureFeedFiles(new Date("2026-08-18T14:00:00+02:00").getTime());
+  const firstDate = dateRange.firstDate.replaceAll("-", "");
+  const lastDate = dateRange.lastDate.replaceAll("-", "");
+  assert.ok(feedFiles["feed_info.txt"].endsWith(`de,fixture-scheduled-2026-08,${firstDate},${lastDate}`));
+  assert.ok(feedFiles["calendar.txt"].endsWith(`1,${firstDate},${lastDate}`));
+  assert.ok(!feedFiles["feed_info.txt"].includes("20260801"));
+  assert.ok(!feedFiles["calendar.txt"].includes("20260831"));
+
+  const artifact = compileScheduledArtifact({
+    sourceUrl: SCHEDULED_MVV_FEED_URL,
+    rawArchiveBytes: new TextEncoder().encode("fixture-transform-deterministic"),
+    feedFiles,
+    retrievedAt: "2026-08-11T10:00:00Z",
+    feedId: "fixture-scheduled-feed",
+  });
+  assert.equal(artifact.feedId, "fixture-scheduled-feed");
+  assert.equal(artifact.serviceDateRange.firstDate, dateRange.firstDate);
+  assert.equal(artifact.serviceDateRange.lastDate, dateRange.lastDate);
+});

--- a/test/scheduled-routing-phase2.test.ts
+++ b/test/scheduled-routing-phase2.test.ts
@@ -24,6 +24,7 @@ import {
 import {
   FIXTURE_SCHEDULED_ACCESS_PROVIDER,
   FIXTURE_SCHEDULED_ARTIFACT,
+  FIXTURE_SCHEDULED_GTFS_FILES,
 } from "../lib/fixtures/scheduled-routing.ts";
 import { MvgScheduledAccessSeedProvider } from "../lib/providers/mvg-scheduled-access.ts";
 import { handleMeetingPost } from "../lib/domain/meeting-api.ts";
@@ -823,3 +824,57 @@ test("configured scheduled artifact errors propagate from the provider factory",
     MEEET_SCHEDULED_MIN_MEMORY_GIB: "4",
   }), ScheduleArtifactUnavailableError);
 });
+
+test("fixture mode honors MEEET_SCHEDULE_ARTIFACT_PATH and keeps the fixture access provider", async () => {
+  const directory = await mkdtemp(join(tmpdir(), "meeet-fixture-artifact-"));
+  try {
+    const dateRange = currentDateRange();
+    const feedFiles = {
+      ...FIXTURE_SCHEDULED_GTFS_FILES,
+      "feed_info.txt": FIXTURE_SCHEDULED_GTFS_FILES["feed_info.txt"]
+        .replace("20260801", dateRange.firstDate.replaceAll("-", ""))
+        .replace("20260831", dateRange.lastDate.replaceAll("-", "")),
+      "calendar.txt": FIXTURE_SCHEDULED_GTFS_FILES["calendar.txt"]
+        .replace("20260801", dateRange.firstDate.replaceAll("-", ""))
+        .replace("20260831", dateRange.lastDate.replaceAll("-", "")),
+    };
+    const artifact = compileScheduledArtifact({
+      sourceUrl: SCHEDULED_MVV_FEED_URL,
+      rawArchiveBytes: new TextEncoder().encode("fixture-factory-test"),
+      feedFiles,
+      retrievedAt: "2026-08-11T10:00:00Z",
+      feedId: "fixture-scheduled-feed",
+    });
+    const path = join(directory, "scheduled-artifact.json");
+    writeScheduledArtifact(path, artifact);
+
+    const providers = createMeetingProviders({
+      MEEET_PROVIDER_MODE: "fixture",
+      MEEET_SCHEDULE_ARTIFACT_PATH: path,
+    });
+    assert.equal(providers.scheduledArtifact?.feedId, "fixture-scheduled-feed");
+    assert.equal(providers.scheduledArtifact?.serviceDateRange.firstDate, dateRange.firstDate);
+    assert.equal(providers.scheduledArtifact?.serviceDateRange.lastDate, dateRange.lastDate);
+    assert.notEqual(providers.scheduledArtifact?.provenance.acquisition.feedValidFrom, "2026-08-01");
+    assert.equal(providers.scheduledAccess?.descriptor.name, "fixture-scheduled-access");
+  } finally {
+    await rm(directory, { recursive: true, force: true });
+  }
+});
+
+test("default fixture mode uses the pre-baked fixture artifact", () => {
+  const providers = createMeetingProviders({ MEEET_PROVIDER_MODE: "fixture" });
+  assert.equal(providers.scheduledArtifact?.feedId, "fixture-scheduled-feed");
+  assert.equal(providers.scheduledArtifact?.provenance.acquisition.feedValidFrom, "2026-08-01");
+  assert.equal(providers.scheduledAccess?.descriptor.name, "fixture-scheduled-access");
+});
+
+function currentDateRange(): { firstDate: string; lastDate: string } {
+  const today = new Date();
+  const firstDate = new Date(Date.UTC(today.getUTCFullYear(), today.getUTCMonth(), today.getUTCDate() - 1));
+  const lastDate = new Date(Date.UTC(today.getUTCFullYear(), today.getUTCMonth(), today.getUTCDate() + 1));
+  return {
+    firstDate: firstDate.toISOString().slice(0, 10),
+    lastDate: lastDate.toISOString().slice(0, 10),
+  };
+}

--- a/test/workflow-guard.test.ts
+++ b/test/workflow-guard.test.ts
@@ -187,6 +187,8 @@ test("PR CI includes an e2e gate that builds, starts meeet, and runs a functiona
   const ciWorkflow = read(".github/workflows/ci.yml");
   assert.match(ciWorkflow, /name:\s*E2E build, spin up, calculate/);
   assert.match(ciWorkflow, /npm run build/);
+  assert.match(ciWorkflow, /schedule:compile:fixture/);
+  assert.match(ciWorkflow, /MEEET_SCHEDULE_ARTIFACT_PATH:\s*\/tmp\/mvv-scheduled-artifact\.json/);
   assert.match(ciWorkflow, /npm start/);
   assert.match(ciWorkflow, /MEEET_PROVIDER_MODE:\s*fixture/);
   assert.match(ciWorkflow, /node scripts\/e2e-calculation\.mjs/);
@@ -200,6 +202,8 @@ test("PR CI includes an e2e gate that builds, starts meeet, and runs a functiona
   assert.match(e2eScript, /"red"/);
   assert.match(e2eScript, /"blue"/);
   assert.match(e2eScript, /stationAreas/);
+  assert.match(e2eScript, /Date\.now/);
+  assert.match(e2eScript, /5 \* 60 \* 1000/);
 });
 
 test("docs describe the feature/dev/main promotion path", () => {


### PR DESCRIPTION
## What

The e2e gate previously based its calculation on the pre-baked `FIXTURE_SCHEDULED_ARTIFACT` (static 2026-08-01..31 validity) with a fixed `2026-08-11T08:05` search start — it never exercised the artifact compilation pipeline and would break once the schedule evolved past that date.

This change makes the gate compile a fresh schedule artifact and calculate at **now + 5 minutes**:

- **`scripts/compile-fixture-schedule.ts`** (new): compiles the hermetic fixture GTFS through the real `compileScheduledArtifact` pipeline — dates re-based to today−1..today+1, stop times shifted so the first departure lands at now+10 min Berlin wall clock (midnight/pre-08:10 wrap handled; GTFS >24h times legal; validation mirrors the consumer).
- **`scripts/fixture-schedule-transform.ts`** (new): shared, parameterized transform (`shiftMinutesFor(nowMs)`, `fixtureFeedFiles(nowMs)`) imported by both the script and the tests — the shift math now has deterministic unit coverage (14:10 / wrapped 31:10 / midnight-crossing 24:00).
- **`lib/providers/factory.ts`**: fixture mode honors `MEEET_SCHEDULE_ARTIFACT_PATH` (loads the compiled artifact, keeps the fixture access provider); without it, behavior is unchanged.
- **`scripts/e2e-calculation.mjs`**: `searchStartAt` = whole-second now + 5 min (no fixed date).
- **`ci.yml`**: e2e job compiles the artifact before starting meeet and points the server at it.
- **Guard tests** pin the compile step, the artifact-path wiring, and the now+5min computation; factory tests pin the provider pairing and the unchanged default.

Still fully hermetic: no external downloads, no MVG API calls, runs any day/time of year.

## Verification

`npm test` (241 pass, 0 fail), `npx tsc --noEmit`, `npm run lint` (0 errors), `git diff --check`, local e2e proof (`E2E OK: v3 calculation returned status "ok" with 3 station areas`, serviceDateRange = current range). Oracle-reviewed on both axes — clean verdict, no remaining remarks.