### PR TITLE
docs(ci): advisory oracle review, agent-driven dev merges, operator-only main promotion (#18)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -30,13 +30,14 @@
 - PRs into `dev` and `main` must pass Node 24 tests, typecheck, and lint on the
   merge result (required check `Validate Node 24 (merge result) / validate`)
   and be up-to-date with their target.
-- PRs into `dev` must additionally pass the e2e gate (required check
+- PRs into `dev` and `main` must pass the e2e gate (required check
   `E2E build, spin up, calculate`): a full application build, a schedule-artifact
   compilation, a server spin-up, and one functional calculation.
-- Reviews are always performed by the oracle (code-review skill, both axes);
-  when the oracle verdict has no remaining remarks, the change may be merged
-  into `dev` without a human review. `main` promotion still requires a human
-  review.
+- Reviews are performed by the oracle (code-review skill, both axes) as an
+  advisory quality gate; the verdict never blocks merging. Branch protection
+  requires no reviews on `dev` or `main`. PRs into `dev` are created and
+  merged by the agent; `dev → main` promotion merges are performed manually
+  by the operator through the GitHub web UI, never by an agent or CLI.
 - `dev` and `main` are protected against force pushes and deletion.
 
 ## Engineering guardrails

--- a/README.md
+++ b/README.md
@@ -46,11 +46,13 @@ service fetches the latest MVV feed and compiles (or keeps) the artifact before
 Changes flow through a single promotion path: `feature/<slug> → dev → main`.
 `main` remains the default production branch. Pull requests into `dev` and
 `main` require Node 24 test/typecheck/lint validation of the merge result (see
-[CI](#validation)); PRs into `dev` additionally require the e2e gate (build,
+[CI](#validation)); PRs into `dev` and `main` require the e2e gate (build,
 spin up, one functional calculation). Reviews are performed by the oracle
-(code-review skill); when its verdict has no remaining remarks the change may
-be merged into `dev` without a human review, while `main` promotion still
-requires a human review. Branches must be up-to-date with their target, and
+(code-review skill) as an advisory quality gate; branch protection requires no
+reviews on `dev` or `main`. PRs into `dev` are created and merged by the
+agent; `dev → main` promotion merges are performed manually by the operator
+through the GitHub web UI, never by an agent or CLI. Branches must be
+up-to-date with their target, and
 force pushes and branch deletion are blocked on `dev` and `main`.
 
 ## Image publication


### PR DESCRIPTION
## Process change (operator decision)

- Oracle review (code-review skill, both axes) is now an **advisory** quality gate — the verdict never blocks merging.
- Branch protection requires **no reviews** on `dev` or `main` (main's 1 required review was removed via the GitHub API; dev had none).
- PRs into `dev` are created and merged by the agent.
- `dev → main` promotion merges are performed manually by the operator through the GitHub web UI — never by an agent or CLI.
- Wording fix: the e2e gate is required on `dev` **and** `main` (was phrased as dev-only).

Docs updated: AGENTS.md (authoritative) + README.md (operator-facing, now carries the full prohibition). Oracle-reviewed on both axes — clean bills; the three minor wording remarks were addressed in the final commit.

Verification: npm test (241 pass, 0 fail), tsc, lint (0 errors), git diff --check.