### PR TITLE
ci(ghcr): publish compiler image with dev tag on dev pushes

### DIFF
--- a/.github/workflows/publish-image.yml
+++ b/.github/workflows/publish-image.yml
@@ -79,10 +79,10 @@ jobs:
           provenance: mode=max
           sbom: true
 
-      # dev and feature branch pushes publish the runner only; main and
-      # release tags additionally publish the compiler.
+      # dev and main branch pushes and release tags publish the compiler;
+      # feature branch pushes publish the runner only.
       - name: Extract compiler image metadata
-        if: github.ref == 'refs/heads/main' || startsWith(github.ref, 'refs/tags/')
+        if: github.ref == 'refs/heads/main' || github.ref == 'refs/heads/dev' || startsWith(github.ref, 'refs/tags/')
         id: meta_compiler
         uses: docker/metadata-action@dc802804100637a589fabce1cb79ff13a1411302
         with:
@@ -93,7 +93,7 @@ jobs:
             type=ref,event=tag
 
       - name: Build and publish compiler
-        if: github.ref == 'refs/heads/main' || startsWith(github.ref, 'refs/tags/')
+        if: github.ref == 'refs/heads/main' || github.ref == 'refs/heads/dev' || startsWith(github.ref, 'refs/tags/')
         id: build_compiler
         uses: docker/build-push-action@53b7df96c91f9c12dcc8a07bcb9ccacbed38856a
         with:

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -59,7 +59,8 @@
 - The documented Unraid production profile is operator-owned and distinct from
   the tracked Compose template; do not overwrite it or infer host-specific
   resource limits.
-- dev and feature branch publication builds the runner image only; the compiler
-  image is published only by `publish-image.yml` on pushes to `main` and
-  release tags. Production is an operator-selected digest-pinned deployment of
-  a `main`-built runner image, and no dev/feature image auto-deploys.
+- Feature branch publication builds the runner image only; the compiler
+  image is published by `publish-image.yml` on pushes to `main` and `dev`
+  and on release tags. Production is an operator-selected digest-pinned
+  deployment of a `main`-built runner image, and no dev/feature image
+  auto-deploys.

--- a/README.md
+++ b/README.md
@@ -58,10 +58,10 @@ force pushes and branch deletion are blocked on `dev` and `main`.
 ## Image publication
 
 Pushes to `main`, `dev`, and `feature/**` branches and release tags trigger the
-unified `publish-image.yml` workflow. `main` and release tags publish both the
-`meeet` (runner) and `meeet-artifact-compiler` (compiler) multi-platform images
-(`linux/amd64`, `linux/arm64`).
-dev and feature branch pushes publish the runner image only. Every published
+unified `publish-image.yml` workflow. `main` and `dev` pushes and release tags
+publish both the `meeet` (runner) and `meeet-artifact-compiler` (compiler)
+multi-platform images (`linux/amd64`, `linux/arm64`); feature branch pushes
+publish the runner image only. Every published
 image gets an immutable `sha-<full-sha>` tag (authoritative, matching the OCI
 revision labels) with build provenance and SBOM attestation.
 Mutable convenience tags are published only for `main` and `dev`. Feature

--- a/docs/application-deployment.md
+++ b/docs/application-deployment.md
@@ -93,9 +93,9 @@ is the default production branch. Pushes to `main`, `dev`, and `feature/**`
 branches and release tags run the unified `publish-image.yml` workflow, which
 validates on Node 24 and builds and publishes the runner
 (`ghcr.io/tiloheidasch/meeet`) multi-platform image (`linux/amd64`,
-`linux/arm64`) on every trigger. `main` and release tags additionally publish
-the compiler (`ghcr.io/tiloheidasch/meeet-artifact-compiler`).
-dev and feature branch pushes publish the runner only. Every published image
+`linux/arm64`) on every trigger. `main` and `dev` pushes and release tags
+additionally publish the compiler (`ghcr.io/tiloheidasch/meeet-artifact-compiler`);
+feature branch pushes publish the runner only. Every published image
 carries an immutable `sha-<full-sha>` tag, OCI revision labels, provenance,
 and SBOM attestation. Mutable
 convenience tags are published only for `main` and `dev`. Feature builds

--- a/test/workflow-guard.test.ts
+++ b/test/workflow-guard.test.ts
@@ -110,14 +110,14 @@ test("documentation does not contain manual compiler dispatch instructions", () 
   }
 });
 
-test("compiler is published only on main pushes and release tags", () => {
+test("compiler is published on main and dev pushes and release tags", () => {
   const job = publishJob(publishWorkflow);
   const compilerGuard =
-    "if: github.ref == 'refs/heads/main' || startsWith(github.ref, 'refs/tags/')";
+    "if: github.ref == 'refs/heads/main' || github.ref == 'refs/heads/dev' || startsWith(github.ref, 'refs/tags/')";
   const guardMatches = job.match(new RegExp(compilerGuard.replace(/[.*+?^${}()|[\]\\]/g, "\\$&"), "g"));
   assert.ok(
     guardMatches && guardMatches.length === 2,
-    "compiler metadata and compiler build steps must both carry the main/tag guard",
+    "compiler metadata and compiler build steps must both carry the main/dev/tag guard",
   );
 
   // The runner build step must not be gated.
@@ -213,14 +213,14 @@ test("docs describe the feature/dev/main promotion path", () => {
   }
 });
 
-test("docs state dev and feature branch pushes publish the runner image only", () => {
-  assert.match(readme, /dev and feature branch pushes publish the runner image only/);
-  assert.match(readme, /`?main`? and release tags publish both/);
+test("docs state feature branch pushes publish the runner image only", () => {
+  assert.match(readme, /feature branch pushes\s+publish the runner image only/);
+  assert.match(readme, /`?main`? and `?dev`? pushes and release tags\s+publish both/);
 });
 
-test("docs state the compiler is published only on main pushes and release tags", () => {
-  assert.match(deploymentGuide, /dev and feature branch pushes publish the runner only/);
-  assert.match(readme, /`?main`? and release tags publish both/);
+test("docs state the compiler is published on main and dev pushes and release tags", () => {
+  assert.match(deploymentGuide, /feature branch pushes\s+publish the runner only/);
+  assert.match(readme, /`?main`? and `?dev`? pushes and release tags\s+publish both/);
 });
 
 test("deployment guide documents GHCR image retention with no automated deletion", () => {


### PR DESCRIPTION
On dev branch pushes the GHCR publish workflow only built the runner; the compiler build was gated to main/tags. This includes `refs/heads/dev` in the compiler metadata and build steps, so dev pushes also publish `ghcr.io/<owner>/meeet-artifact-compiler:dev` (+ `sha-<long>`), matching the runner tags. Feature-branch pushes still publish the runner only.