### PR TITLE
ci(ghcr): publish linux/amd64 only and drop QEMU emulation (#36)

### DIFF
--- a/.github/workflows/publish-image.yml
+++ b/.github/workflows/publish-image.yml
@@ -29,9 +29,6 @@ jobs:
       - name: Check out source
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1
 
-      - name: Set up QEMU
-        uses: docker/setup-qemu-action@96fe6ef7f33517b61c61be40b68a1882f3264fb8
-
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@bb05f3f5519dd87d3ba754cc423b652a5edd6d2c
 
@@ -67,7 +64,7 @@ jobs:
           context: .
           file: ./Dockerfile
           target: runner
-          platforms: linux/amd64,linux/arm64
+          platforms: linux/amd64
           push: true
           tags: ${{ steps.meta_runner.outputs.tags }}
           labels: ${{ steps.meta_runner.outputs.labels }}
@@ -100,7 +97,7 @@ jobs:
           context: .
           file: ./Dockerfile
           target: artifact-compiler
-          platforms: linux/amd64,linux/arm64
+          platforms: linux/amd64
           push: true
           tags: ${{ steps.meta_compiler.outputs.tags }}
           labels: ${{ steps.meta_compiler.outputs.labels }}

--- a/README.md
+++ b/README.md
@@ -60,7 +60,7 @@ force pushes and branch deletion are blocked on `dev` and `main`.
 Pushes to `main`, `dev`, and `feature/**` branches and release tags trigger the
 unified `publish-image.yml` workflow. `main` and `dev` pushes and release tags
 publish both the `meeet` (runner) and `meeet-artifact-compiler` (compiler)
-multi-platform images (`linux/amd64`, `linux/arm64`); feature branch pushes
+images for `linux/amd64`; feature branch pushes
 publish the runner image only. Every published
 image gets an immutable `sha-<full-sha>` tag (authoritative, matching the OCI
 revision labels) with build provenance and SBOM attestation.

--- a/README.md
+++ b/README.md
@@ -60,10 +60,9 @@ force pushes and branch deletion are blocked on `dev` and `main`.
 Pushes to `main`, `dev`, and `feature/**` branches and release tags trigger the
 unified `publish-image.yml` workflow. `main` and `dev` pushes and release tags
 publish both the `meeet` (runner) and `meeet-artifact-compiler` (compiler)
-images for `linux/amd64`; feature branch pushes
-publish the runner image only. Every published
-image gets an immutable `sha-<full-sha>` tag (authoritative, matching the OCI
-revision labels) with build provenance and SBOM attestation.
+images for `linux/amd64`; feature branch pushes publish the runner image only.
+Every published image gets an immutable `sha-<full-sha>` tag (authoritative,
+matching the OCI revision labels) with build provenance and SBOM attestation.
 Mutable convenience tags are published only for `main` and `dev`. Feature
 builds additionally get a branch-reference tag normalized to a valid Docker tag
 by docker/metadata-action (for example `feature/18-branch-based-development`

--- a/docs/application-deployment.md
+++ b/docs/application-deployment.md
@@ -92,8 +92,7 @@ Changes flow through the promotion path `feature/<slug> → dev → main`; `main
 is the default production branch. Pushes to `main`, `dev`, and `feature/**`
 branches and release tags run the unified `publish-image.yml` workflow, which
 validates on Node 24 and builds and publishes the runner
-(`ghcr.io/tiloheidasch/meeet`) multi-platform image (`linux/amd64`,
-`linux/arm64`) on every trigger. `main` and `dev` pushes and release tags
+(`ghcr.io/tiloheidasch/meeet`) image for `linux/amd64` on every trigger. `main` and `dev` pushes and release tags
 additionally publish the compiler (`ghcr.io/tiloheidasch/meeet-artifact-compiler`);
 feature branch pushes publish the runner only. Every published image
 carries an immutable `sha-<full-sha>` tag, OCI revision labels, provenance,

--- a/docs/application-deployment.md
+++ b/docs/application-deployment.md
@@ -92,7 +92,8 @@ Changes flow through the promotion path `feature/<slug> → dev → main`; `main
 is the default production branch. Pushes to `main`, `dev`, and `feature/**`
 branches and release tags run the unified `publish-image.yml` workflow, which
 validates on Node 24 and builds and publishes the runner
-(`ghcr.io/tiloheidasch/meeet`) image for `linux/amd64` on every trigger. `main` and `dev` pushes and release tags
+(`ghcr.io/tiloheidasch/meeet`) image for `linux/amd64` on every trigger.
+`main` and `dev` pushes and release tags
 additionally publish the compiler (`ghcr.io/tiloheidasch/meeet-artifact-compiler`);
 feature branch pushes publish the runner only. Every published image
 carries an immutable `sha-<full-sha>` tag, OCI revision labels, provenance,

--- a/test/workflow-guard.test.ts
+++ b/test/workflow-guard.test.ts
@@ -59,13 +59,12 @@ test("validation job runs Node 24 checks before publication", () => {
   assert.match(ciWorkflow, /name:\s*Validate Node 24 \(merge result\)/);
 });
 
-test("publish job builds and publishes both runner and compiler images with multi-platform and provenance", () => {
+test("publish job builds and publishes both runner and compiler images for linux/amd64 only with provenance", () => {
   const job = publishJob(publishWorkflow);
 
   // Runner image configuration
   assert.match(job, /images:\s*ghcr\.io\/\${{\s*steps\.owner\.outputs\.owner\s*}}\/meeet\b/);
   assert.match(job, /target:\s*runner/);
-  assert.match(job, /platforms:\s*linux\/amd64,linux\/arm64/);
   assert.match(job, /cache-from:\s*type=gha,scope=meeet-runner/);
   assert.match(job, /cache-to:\s*type=gha,mode=max,scope=meeet-runner/);
 
@@ -74,6 +73,11 @@ test("publish job builds and publishes both runner and compiler images with mult
   assert.match(job, /target:\s*artifact-compiler/);
   assert.match(job, /cache-from:\s*type=gha,scope=meeet-compiler/);
   assert.match(job, /cache-to:\s*type=gha,mode=max,scope=meeet-compiler/);
+
+  // Both runner and compiler builds target linux/amd64 as the single platform.
+  const platformMatches = job.match(/platforms:\s*[^\n]+/g);
+  assert.ok(platformMatches && platformMatches.length === 2, "both runner and compiler must declare a platforms: line");
+  assert.deepEqual(platformMatches, ["platforms: linux/amd64", "platforms: linux/amd64"]);
 
   // Shared tags and provenance settings
   const tagMatches = job.match(/type=sha,format=long,prefix=sha-/g);
@@ -84,6 +88,11 @@ test("publish job builds and publishes both runner and compiler images with mult
   // Digest summary
   assert.match(job, /MEEET_IMAGE=ghcr\.io\/\${GHCR_OWNER}\/meeet@\${RUNNER_DIGEST}/);
   assert.match(job, /MEEET_COMPILER_IMAGE=ghcr\.io\/\${GHCR_OWNER}\/meeet-artifact-compiler@\${COMPILER_DIGEST}/);
+});
+
+test("publish workflow targets linux/amd64 only and does not set up QEMU", () => {
+  assert.doesNotMatch(publishWorkflow, /linux\/arm64/, "arm64 builds must be dropped");
+  assert.doesNotMatch(publishWorkflow, /setup-qemu-action|QEMU/i, "QEMU emulation setup must be removed");
 });
 
 test("grants registry write permissions only in the publish job under least privilege", () => {


### PR DESCRIPTION
Closes #36

## Summary

Drops `linux/arm64` container image builds and the QEMU emulation step from the unified `publish-image.yml` workflow. The deployment target (Unraid x86_64 host) only requires `linux/amd64`, and removing cross-arch emulation drastically cuts CI build latency.

Note: the issue references `publish-runner.yml`/`publish-compiler.yml`, but those were previously consolidated into the single `.github/workflows/publish-image.yml` (guard-tested); the change lands there.

## Changes

- **`.github/workflows/publish-image.yml`**: both runner and compiler builds now target `platforms: linux/amd64`; removed the `docker/setup-qemu-action` step.
- **`test/workflow-guard.test.ts`**: asserts exactly two `platforms: linux/amd64` lines (deepEqual, so arm64 cannot silently return) and a new test asserting no `linux/arm64` or QEMU references remain.
- **`README.md` / `docs/application-deployment.md`**: platform references updated to the `linux/amd64` single-architecture target.

## Verification

- `npm test`: 242 pass / 0 fail
- `npx tsc --noEmit`: clean
- `npm run lint`: 0 errors
- `git diff --check`: clean
- Oracle review (code-review skill, Standards + Spec axes): no remarks