### PR TITLE
fix(ci): eliminate GitHub Actions warnings (#22)

### DIFF
--- a/.github/workflows/publish-image.yml
+++ b/.github/workflows/publish-image.yml
@@ -33,7 +33,7 @@ jobs:
         uses: docker/setup-qemu-action@96fe6ef7f33517b61c61be40b68a1882f3264fb8
 
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@bb05f3f5519dd87d3ba754cc423b652a5edd6d2c
+        uses: docker/setup-buildx-action@37fe631027851001ddb9b187196cc803df7f5f0e
 
       - name: Normalize GHCR owner
         id: owner

--- a/app/api/health/ready/route.ts
+++ b/app/api/health/ready/route.ts
@@ -5,7 +5,7 @@ import { connection } from "next/server";
 import { loadScheduledArtifact } from "../../../../lib/domain/scheduled-routing/artifact.ts";
 import { readProviderConfig } from "../../../../lib/providers/config.ts";
 
-export async function GET(_request: Request): Promise<Response> {
+export async function GET(): Promise<Response> {
   await connection();
   return readinessResponse();
 }

--- a/lib/domain/route-first/meeting-service.ts
+++ b/lib/domain/route-first/meeting-service.ts
@@ -744,7 +744,7 @@ export function runRouteFirstMeetingService(
     let normalizedJourneys: readonly RouteJourney[];
     try {
       normalizedJourneys = input.journeys.map((journey) => normalizeRouteJourney(journey));
-    } catch (error) {
+    } catch {
       return incomplete(input, "missing-coverage", enumerationEvidence);
     }
     const certifiedPathKeys = new Set<string>();
@@ -858,7 +858,7 @@ export function runRouteFirstMeetingService(
         const profiles = input.targetProfiles.filter((profile) => profile.edgeId === edge.id);
         fairRegions.push(allParticipantToleranceRegion(profiles, tolerance));
       }
-    } catch (error) {
+    } catch {
       return incomplete(input, "missing-coverage", enumerationEvidence);
     }
     const fairRegionGeometry: RouteFirstFairRegionGeometry[] = relevantEdges.map((edge) => ({ edgeId: edge.id, start: wireCoordinate(edge.start), end: wireCoordinate(edge.end) }));

--- a/lib/domain/scheduled-routing/artifact.ts
+++ b/lib/domain/scheduled-routing/artifact.ts
@@ -170,7 +170,7 @@ export function writeScheduledArtifact(path: string, artifact: ScheduledRoutingA
   const absolutePath = resolve(path);
   validateArtifactStructure(artifact);
   const { compiledArtifactId, ...identity } = artifact.provenance;
-  const { provenance: _provenance, ...core } = artifact;
+  const { provenance, ...core } = artifact;
   if (calculateScheduledContentHash(identity.feedId, identity.timeZone, identity.files) !== identity.contentHash || calculateScheduledCompiledArtifactId(core, identity) !== compiledArtifactId) {
     throw new ScheduleArtifactUnavailableError("The scheduled artifact identity does not match its contents.");
   }
@@ -186,7 +186,7 @@ export function writeScheduledArtifact(path: string, artifact: ScheduledRoutingA
     payloadSha256: sha256Bytes(payload),
     compiledArtifactId,
     summary: bundleSummary(core),
-    provenance: artifact.provenance,
+    provenance,
     compilerVersion: SCHEDULED_COMPILER_VERSION,
   };
   const directory = dirname(absolutePath);
@@ -353,7 +353,7 @@ export function loadScheduledArtifact(
   if (!isScheduledRoutingArtifact(parsed)) throw new ScheduleArtifactUnavailableError("The configured scheduled artifact failed schema validation.");
   validateArtifactStructure(parsed);
   const { compiledArtifactId, ...identity } = parsed.provenance;
-  const { provenance: _provenance, ...core } = parsed;
+  const { provenance, ...core } = parsed;
   if (calculateScheduledContentHash(identity.feedId, identity.timeZone, identity.files) !== identity.contentHash) {
     throw new ScheduleArtifactUnavailableError("The configured scheduled artifact file-hash content identity does not match its provenance.");
   }
@@ -362,7 +362,7 @@ export function loadScheduledArtifact(
   }
   validateBundleSummary(manifest.summary, core);
   validateRawArchive(parsed, options.rawArchiveBytes);
-  validateFreshness(parsed.provenance.acquisition, options.now ?? defaultLoaderNow());
+  validateFreshness(provenance.acquisition, options.now ?? defaultLoaderNow());
   const frozen = deepFreeze(parsed);
   loadedScheduledArtifacts.set(absolutePath, frozen);
   return frozen;

--- a/lib/providers/self-hosted-routing.ts
+++ b/lib/providers/self-hosted-routing.ts
@@ -147,7 +147,7 @@ export class OtpGraphqlRoutingProvider implements PointToPointRoutingProvider {
             origin: toOtpLocation(request.origin, "origin"),
             destination: toOtpLocation(request.destination, "destination"),
             dateTime: toOtpDateTime(request.departureAt),
-            modes: toOtpModes(this.config.otpProfile),
+            modes: toOtpModes(),
             first: OTP_PAGE_SIZE,
             after,
           },
@@ -995,7 +995,7 @@ function toOtpDateTime(departureAt: string): { earliestDeparture: string } {
   return { earliestDeparture: departureAt };
 }
 
-function toOtpModes(_profile: string): {
+function toOtpModes(): {
   transit: {
     access: Array<"WALK">;
     egress: Array<"WALK">;


### PR DESCRIPTION
Closes #22

## Changes

**Warning group 1 — Node 20 action deprecation**
- Bump `docker/setup-buildx-action` pin from v4.2.0 (`bb05f3f5…`) to v4.3.0 (`37fe6310…`), the newest release, which targets Node 24 (`runs.using: node24`). All other workflow actions were already re-pinned to their newest Node-24 releases by #19; verified via GitHub API: checkout v7.0.1, setup-node v7.0.0, setup-qemu-action v4.2.0, login-action v4.6.0, metadata-action v6.2.0, build-push-action v7.3.0 — all `node24`.

**Warning group 2 — ESLint warnings (6 → 0)**
- `app/api/health/ready/route.ts` — drop unused `_request` param from GET handler
- `lib/domain/route-first/meeting-service.ts` — `catch (error)` → `catch {` in two blocks that don't use the error
- `lib/domain/scheduled-routing/artifact.ts` — destructure `provenance` and use it instead of `_provenance` (two spots)
- `lib/providers/self-hosted-routing.ts` — remove unused `_profile` param from `toOtpModes` and its call site

## Verification
- `npm run lint`: 0 warnings, 0 errors
- `npx tsc --noEmit`: clean
- `npm test`: 241 pass, 1 pre-existing skip
- `git diff --check`: clean
- Oracle review (both axes): no remarks