### PR TITLE
Promote dev to main

### DIFF
--- a/.github/workflows/publish-image.yml
+++ b/.github/workflows/publish-image.yml
@@ -29,9 +29,6 @@ jobs:
       - name: Check out source
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1
 
-      - name: Set up QEMU
-        uses: docker/setup-qemu-action@96fe6ef7f33517b61c61be40b68a1882f3264fb8
-
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@bb05f3f5519dd87d3ba754cc423b652a5edd6d2c
 
@@ -67,7 +64,7 @@ jobs:
           context: .
           file: ./Dockerfile
           target: runner
-          platforms: linux/amd64,linux/arm64
+          platforms: linux/amd64
           push: true
           tags: ${{ steps.meta_runner.outputs.tags }}
           labels: ${{ steps.meta_runner.outputs.labels }}
@@ -100,7 +97,7 @@ jobs:
           context: .
           file: ./Dockerfile
           target: artifact-compiler
-          platforms: linux/amd64,linux/arm64
+          platforms: linux/amd64
           push: true
           tags: ${{ steps.meta_compiler.outputs.tags }}
           labels: ${{ steps.meta_compiler.outputs.labels }}

--- a/.github/workflows/publish-image.yml
+++ b/.github/workflows/publish-image.yml
@@ -33,7 +33,7 @@ jobs:
         uses: docker/setup-qemu-action@96fe6ef7f33517b61c61be40b68a1882f3264fb8
 
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@bb05f3f5519dd87d3ba754cc423b652a5edd6d2c
+        uses: docker/setup-buildx-action@37fe631027851001ddb9b187196cc803df7f5f0e
 
       - name: Normalize GHCR owner
         id: owner

--- a/README.md
+++ b/README.md
@@ -60,7 +60,7 @@ force pushes and branch deletion are blocked on `dev` and `main`.
 Pushes to `main`, `dev`, and `feature/**` branches and release tags trigger the
 unified `publish-image.yml` workflow. `main` and `dev` pushes and release tags
 publish both the `meeet` (runner) and `meeet-artifact-compiler` (compiler)
-multi-platform images (`linux/amd64`, `linux/arm64`); feature branch pushes
+images for `linux/amd64`; feature branch pushes
 publish the runner image only. Every published
 image gets an immutable `sha-<full-sha>` tag (authoritative, matching the OCI
 revision labels) with build provenance and SBOM attestation.

--- a/README.md
+++ b/README.md
@@ -60,10 +60,9 @@ force pushes and branch deletion are blocked on `dev` and `main`.
 Pushes to `main`, `dev`, and `feature/**` branches and release tags trigger the
 unified `publish-image.yml` workflow. `main` and `dev` pushes and release tags
 publish both the `meeet` (runner) and `meeet-artifact-compiler` (compiler)
-images for `linux/amd64`; feature branch pushes
-publish the runner image only. Every published
-image gets an immutable `sha-<full-sha>` tag (authoritative, matching the OCI
-revision labels) with build provenance and SBOM attestation.
+images for `linux/amd64`; feature branch pushes publish the runner image only.
+Every published image gets an immutable `sha-<full-sha>` tag (authoritative,
+matching the OCI revision labels) with build provenance and SBOM attestation.
 Mutable convenience tags are published only for `main` and `dev`. Feature
 builds additionally get a branch-reference tag normalized to a valid Docker tag
 by docker/metadata-action (for example `feature/18-branch-based-development`

--- a/app/api/health/ready/route.ts
+++ b/app/api/health/ready/route.ts
@@ -5,7 +5,7 @@ import { connection } from "next/server";
 import { loadScheduledArtifact } from "../../../../lib/domain/scheduled-routing/artifact.ts";
 import { readProviderConfig } from "../../../../lib/providers/config.ts";
 
-export async function GET(_request: Request): Promise<Response> {
+export async function GET(): Promise<Response> {
   await connection();
   return readinessResponse();
 }

--- a/components/MapLibreCanvas.tsx
+++ b/components/MapLibreCanvas.tsx
@@ -5,6 +5,7 @@ import { AttributionControl, Map, Marker, NavigationControl, setWorkerUrl, type 
 import "maplibre-gl/dist/maplibre-gl.css";
 import type { MeetingStationArea, StationAreaMode } from "@/lib/client/meeting-response";
 import { buildStationTerritories, type StationTerritory } from "@/lib/client/station-territories";
+import { STATION_ICON_PADDING, STATION_ICON_VISUAL_SIZES } from "@/lib/client/station-icon-sizes";
 
 export type MapParticipant = { id: string; number: number; label: string; latitude: number; longitude: number; color: "#e85d4a" | "#3d70c9" };
 type Props = { participants: readonly MapParticipant[]; stationAreas: readonly MeetingStationArea[]; resultState: "initial" | "ok" | "no-result"; selectedStationAreaId?: string | null; onStationAreaSelect?: (stationAreaId: string) => void };
@@ -13,9 +14,10 @@ type FeatureCollection = { type: "FeatureCollection"; features: Array<{ type: "F
 const MUNICH_CENTER: [number, number] = [11.576, 48.137];
 const DEFAULT_MAP_STYLE_URL = "https://tiles.openfreemap.org/styles/liberty";
 const TERRITORY_FILL_OPACITY = 0.4;
-const STATION_LAYERS = ["meeet-stations-red", "meeet-stations-blue", "meeet-stations-fair", "meeet-stations-unclassified"];
+/** Station icon layers in paint order, bottommost first: bus < tram < ubahn < sbahn. */
+const STATION_ICON_PAINT_ORDER: readonly StationAreaMode[] = ["bus", "tram", "ubahn", "sbahn"];
+const STATION_ICON_LAYERS = STATION_ICON_PAINT_ORDER.map((mode) => `meeet-stations-${mode}`);
 const STATION_COLORS = { red: "#e85d4a", blue: "#3d70c9", fair: "#f0ca43", unclassified: "#65716a" } as const;
-const STATION_MODES: readonly StationAreaMode[] = ["sbahn", "ubahn", "tram", "bus"] as const;
 setWorkerUrl("/vendor/maplibre-gl/maplibre-gl-worker.mjs");
 
 const S_PATH_D = "M 472 131 L 471 132 L 458 132 L 457 133 L 448 133 L 447 134 L 434 135 L 433 136 L 428 136 L 398 143 L 376 150 L 356 158 L 330 171 L 312 182 L 286 202 L 265 223 L 253 238 L 242 255 L 229 282 L 223 300 L 219 317 L 218 329 L 217 330 L 217 340 L 216 341 L 217 384 L 218 385 L 220 403 L 227 428 L 231 438 L 243 461 L 249 470 L 266 490 L 292 512 L 319 529 L 350 544 L 406 564 L 409 564 L 416 567 L 444 574 L 448 576 L 455 577 L 459 579 L 496 588 L 500 590 L 507 591 L 546 603 L 549 605 L 557 607 L 572 614 L 574 614 L 590 622 L 604 631 L 622 647 L 630 658 L 636 670 L 640 687 L 640 705 L 637 716 L 632 726 L 624 737 L 608 752 L 596 760 L 578 769 L 564 774 L 548 778 L 537 779 L 536 780 L 496 781 L 495 780 L 483 780 L 482 779 L 468 778 L 467 777 L 462 777 L 461 776 L 456 776 L 446 773 L 442 773 L 405 762 L 402 760 L 387 755 L 380 751 L 378 751 L 343 733 L 312 713 L 276 684 L 248 656 L 232 637 L 222 623 L 222 770 L 248 791 L 290 817 L 332 837 L 352 845 L 360 847 L 363 849 L 366 849 L 369 851 L 375 852 L 395 859 L 419 865 L 423 865 L 428 867 L 443 869 L 444 870 L 450 870 L 451 871 L 463 872 L 464 873 L 472 873 L 473 874 L 501 875 L 502 876 L 542 875 L 543 874 L 561 873 L 562 872 L 568 872 L 569 871 L 590 868 L 610 863 L 617 860 L 620 860 L 647 850 L 674 837 L 700 821 L 728 799 L 751 776 L 767 756 L 777 741 L 793 711 L 799 696 L 806 673 L 806 669 L 809 658 L 809 652 L 810 651 L 810 642 L 811 641 L 810 600 L 809 599 L 809 592 L 808 591 L 806 576 L 798 550 L 789 531 L 778 514 L 771 505 L 752 486 L 726 467 L 694 450 L 692 450 L 667 439 L 619 424 L 571 412 L 554 409 L 541 405 L 537 405 L 505 397 L 501 395 L 494 394 L 477 388 L 474 388 L 443 376 L 421 364 L 409 355 L 398 344 L 392 336 L 386 325 L 382 313 L 381 302 L 380 301 L 380 284 L 381 283 L 382 274 L 390 256 L 404 240 L 418 230 L 441 220 L 458 217 L 459 216 L 466 216 L 467 215 L 508 215 L 509 216 L 519 216 L 520 217 L 527 217 L 528 218 L 546 220 L 572 226 L 603 236 L 623 245 L 625 245 L 662 264 L 689 281 L 716 301 L 752 333 L 766 348 L 766 225 L 743 208 L 721 194 L 679 172 L 677 172 L 670 168 L 645 158 L 603 145 L 595 144 L 576 139 L 566 138 L 565 137 L 559 137 L 558 136 L 552 136 L 544 134 L 536 134 L 535 133 L 508 132 L 507 131 Z";
@@ -51,8 +53,8 @@ function stationData(areas: readonly MeetingStationArea[]): FeatureCollection {
 /** Padded high-DPI station glyph icon rendered on a canvas. */
 function stationGlyphImage(mode: StationAreaMode, color: string): ImageData {
   const pixelRatio = 2;
-  const visualSize = 18;
-  const padding = 11;
+  const visualSize = STATION_ICON_VISUAL_SIZES[mode];
+  const padding = STATION_ICON_PADDING;
   const totalSize = visualSize + padding * 2;
   const canvas = document.createElement("canvas");
   canvas.width = totalSize * pixelRatio;
@@ -144,8 +146,8 @@ function stationGlyphImage(mode: StationAreaMode, color: string): ImageData {
 /** Padded high-DPI selection outline indicator for selected station area. */
 function selectedStationOutlineImage(mode: StationAreaMode): ImageData {
   const pixelRatio = 2;
-  const visualSize = 18;
-  const padding = 11;
+  const visualSize = STATION_ICON_VISUAL_SIZES[mode];
+  const padding = STATION_ICON_PADDING;
   const totalSize = visualSize + padding * 2;
   const canvas = document.createElement("canvas");
   canvas.width = totalSize * pixelRatio;
@@ -261,21 +263,23 @@ export default function MapLibreCanvas({ participants, stationAreas, resultState
 
         map.addSource("meeet-station-areas", { type: "geojson", data: stationData([]) });
 
-        STATION_MODES.forEach((mode) => {
+        STATION_ICON_PAINT_ORDER.forEach((mode) => {
           (["red", "blue", "fair", "unclassified"] as const).forEach((classification) => {
             map!.addImage(`meeet-station-${mode}-${classification}`, stationGlyphImage(mode, STATION_COLORS[classification]), { pixelRatio: 2 });
           });
           map!.addImage(`meeet-selected-station-${mode}`, selectedStationOutlineImage(mode), { pixelRatio: 2 });
         });
 
-        (["red", "blue", "fair", "unclassified"] as const).forEach((classification) => {
+        STATION_ICON_PAINT_ORDER.forEach((mode) => {
           map!.addLayer({
-            id: `meeet-stations-${classification}`,
+            id: `meeet-stations-${mode}`,
             type: "symbol",
             source: "meeet-station-areas",
-            filter: ["==", ["get", "classification"], classification],
+            // The coalesce keeps the pre-existing defensive bus default for features without a mode
+            // (unreachable via stationData, which always sets mode).
+            filter: ["==", ["coalesce", ["get", "mode"], "bus"], mode],
             layout: {
-              "icon-image": ["concat", "meeet-station-", ["coalesce", ["get", "mode"], "bus"], `-${classification}`],
+              "icon-image": ["concat", `meeet-station-${mode}-`, ["get", "classification"]],
               "icon-allow-overlap": true,
               "icon-ignore-placement": true,
               "icon-anchor": "center",
@@ -283,6 +287,9 @@ export default function MapLibreCanvas({ participants, stationAreas, resultState
           });
         });
 
+        // The selection outline is intentionally the topmost canvas layer: it is the selected
+        // station's selection indicator (not a transit icon in the ordering) and must wrap the
+        // icon to be visible.
         map.addLayer({
           id: "meeet-selected-station-area",
           type: "symbol",
@@ -310,9 +317,9 @@ export default function MapLibreCanvas({ participants, stationAreas, resultState
         };
         const hideTooltip = () => setTooltip(null);
 
-        map.on("click", STATION_LAYERS, select);
+        map.on("click", STATION_ICON_LAYERS, select);
         map.on("mouseout", hideTooltip);
-        STATION_LAYERS.forEach((layer) => {
+        STATION_ICON_LAYERS.forEach((layer) => {
           map!.on("mouseenter", layer, () => { map!.getCanvas().style.cursor = "pointer"; });
           map!.on("mouseleave", layer, () => { map!.getCanvas().style.cursor = ""; });
           map!.on("mouseenter", layer, hover);
@@ -352,7 +359,7 @@ export default function MapLibreCanvas({ participants, stationAreas, resultState
     syncOrigins(map, participants, markersRef);
     const markReady = () => {
       if (!map || map !== mapRef.current) return;
-      const ready = stationAreas.length === 0 || stationAreas.every((area) => map.queryRenderedFeatures(map.project([area.coordinate.longitude, area.coordinate.latitude]), { layers: STATION_LAYERS }).some((feature) => feature.properties?.stationAreaId === area.stationAreaId));
+      const ready = stationAreas.length === 0 || stationAreas.every((area) => map.queryRenderedFeatures(map.project([area.coordinate.longitude, area.coordinate.latitude]), { layers: STATION_ICON_LAYERS }).some((feature) => feature.properties?.stationAreaId === area.stationAreaId));
       if (ready) setMarkersReady(true);
     };
     map.once("idle", markReady);

--- a/docs/application-deployment.md
+++ b/docs/application-deployment.md
@@ -92,8 +92,7 @@ Changes flow through the promotion path `feature/<slug> → dev → main`; `main
 is the default production branch. Pushes to `main`, `dev`, and `feature/**`
 branches and release tags run the unified `publish-image.yml` workflow, which
 validates on Node 24 and builds and publishes the runner
-(`ghcr.io/tiloheidasch/meeet`) multi-platform image (`linux/amd64`,
-`linux/arm64`) on every trigger. `main` and `dev` pushes and release tags
+(`ghcr.io/tiloheidasch/meeet`) image for `linux/amd64` on every trigger. `main` and `dev` pushes and release tags
 additionally publish the compiler (`ghcr.io/tiloheidasch/meeet-artifact-compiler`);
 feature branch pushes publish the runner only. Every published image
 carries an immutable `sha-<full-sha>` tag, OCI revision labels, provenance,

--- a/docs/application-deployment.md
+++ b/docs/application-deployment.md
@@ -92,7 +92,8 @@ Changes flow through the promotion path `feature/<slug> → dev → main`; `main
 is the default production branch. Pushes to `main`, `dev`, and `feature/**`
 branches and release tags run the unified `publish-image.yml` workflow, which
 validates on Node 24 and builds and publishes the runner
-(`ghcr.io/tiloheidasch/meeet`) image for `linux/amd64` on every trigger. `main` and `dev` pushes and release tags
+(`ghcr.io/tiloheidasch/meeet`) image for `linux/amd64` on every trigger.
+`main` and `dev` pushes and release tags
 additionally publish the compiler (`ghcr.io/tiloheidasch/meeet-artifact-compiler`);
 feature branch pushes publish the runner only. Every published image
 carries an immutable `sha-<full-sha>` tag, OCI revision labels, provenance,

--- a/e2e/meeting.spec.ts
+++ b/e2e/meeting.spec.ts
@@ -2,6 +2,7 @@ import { expect, test, type Page } from "@playwright/test";
 import { inflateSync } from "node:zlib";
 import http from "node:http";
 import type net from "node:net";
+import { STATION_ICON_PADDING, STATION_ICON_SPEC_RATIOS } from "../lib/client/station-icon-sizes";
 
 const MAP_STYLE = "https://tiles.openfreemap.org/styles/liberty";
 const MAP_ORIGIN = "https://tiles.openfreemap.org";
@@ -295,11 +296,32 @@ test.describe("v3 Munich meeting surface", () => {
     const origin1Text = await origin1.textContent();
     expect(origin1Text?.trim()).toBe("");
 
-    // Station markers on MapLibre canvas use symbol layers
+    // Participant pins are DOM markers above the canvas: no icon occludes them
+    // (scroll the map into view first so the markers are inside the viewport for element hit-testing)
+    await page.locator(".map-frame").evaluate((frame) => frame.scrollIntoView({ block: "center" }));
+    const originPinsOnTop = await page.evaluate(() => {
+      return [...document.querySelectorAll(".meeet-origin-marker")].map((marker) => {
+        const rect = marker.getBoundingClientRect();
+        const points = [
+          { x: rect.x + rect.width / 2, y: rect.y + rect.height / 2 },
+          { x: rect.x + 1, y: rect.y + 1 },
+          { x: rect.x + rect.width - 1, y: rect.y + 1 },
+          { x: rect.x + 1, y: rect.y + rect.height - 1 },
+          { x: rect.x + rect.width - 1, y: rect.y + rect.height - 1 },
+        ];
+        return points.every((point) => {
+          const top = document.elementsFromPoint(point.x, point.y)[0];
+          return !!top && top.closest(".meeet-origin-marker") !== null;
+        });
+      });
+    });
+    expect(originPinsOnTop).toEqual([true, true]);
+
+    // Station markers on MapLibre canvas use per-mode symbol layers
     const layerTypes = await page.evaluate(() => {
       const map = (window as unknown as { __meeetMap?: { getLayer: (id: string) => { type: string } | undefined; getLayoutProperty: (id: string, name: string) => unknown } }).__meeetMap;
       if (!map) throw new Error("Map instance unavailable");
-      return ["meeet-stations-red", "meeet-stations-blue", "meeet-stations-fair", "meeet-stations-unclassified"].map((id) => {
+      return ["meeet-stations-bus", "meeet-stations-tram", "meeet-stations-ubahn", "meeet-stations-sbahn"].map((id) => {
         const layer = map.getLayer(id);
         const image = map.getLayoutProperty(id, "icon-image");
         return { id, type: layer?.type, image };
@@ -309,6 +331,40 @@ test.describe("v3 Munich meeting surface", () => {
       expect(layer.type).toBe("symbol");
       expect(layer.image).toBeDefined();
     }
+
+    // Strict paint order: bus < tram < ubahn < sbahn < selection outline; participant pins are DOM markers above the canvas (asserted above)
+    const layerOrder = await page.evaluate(() => {
+      const map = (window as unknown as { __meeetMap?: { getStyle: () => { layers: Array<{ id: string }> } } }).__meeetMap;
+      if (!map) throw new Error("Map instance unavailable");
+      return map.getStyle().layers.map((layer) => layer.id);
+    });
+    const indexOf = (id: string) => layerOrder.indexOf(id);
+    expect(indexOf("meeet-stations-bus")).toBeGreaterThanOrEqual(0);
+    expect(indexOf("meeet-stations-tram")).toBeGreaterThan(indexOf("meeet-stations-bus"));
+    expect(indexOf("meeet-stations-ubahn")).toBeGreaterThan(indexOf("meeet-stations-tram"));
+    expect(indexOf("meeet-stations-sbahn")).toBeGreaterThan(indexOf("meeet-stations-ubahn"));
+    expect(indexOf("meeet-selected-station-area")).toBeGreaterThan(indexOf("meeet-stations-sbahn"));
+
+    // Size hierarchy matches the issue #39 spec ratios: sbahn 200%, ubahn 166%, tram 133%, bus 100% of the bus visual size
+    // (visual size = image width / pixelRatio minus the padding on each side)
+    const iconSizes = await page.evaluate((iconPadding: number) => {
+      const map = (window as unknown as { __meeetMap?: { getImage: (id: string) => { data: { width: number }; pixelRatio: number } | undefined } }).__meeetMap;
+      if (!map) throw new Error("Map instance unavailable");
+      const visualSize = (id: string) => {
+        const image = map.getImage(id);
+        if (!image) throw new Error(`Image ${id} missing`);
+        return image.data.width / image.pixelRatio - 2 * iconPadding;
+      };
+      return {
+        sbahn: visualSize("meeet-station-sbahn-red"),
+        ubahn: visualSize("meeet-station-ubahn-red"),
+        tram: visualSize("meeet-station-tram-red"),
+        bus: visualSize("meeet-station-bus-red"),
+      };
+    }, STATION_ICON_PADDING);
+    expect(iconSizes.sbahn / iconSizes.bus).toBeCloseTo(STATION_ICON_SPEC_RATIOS.sbahn, 5);
+    expect(iconSizes.ubahn / iconSizes.bus).toBeCloseTo(STATION_ICON_SPEC_RATIOS.ubahn, 5);
+    expect(iconSizes.tram / iconSizes.bus).toBeCloseTo(STATION_ICON_SPEC_RATIOS.tram, 5);
 
     // Legend swatches for all classifications are visible
     for (const color of ["red", "blue", "fair", "neutral"]) {

--- a/lib/client/station-icon-sizes.ts
+++ b/lib/client/station-icon-sizes.ts
@@ -1,0 +1,10 @@
+import type { StationAreaMode } from "@/lib/client/meeting-response";
+
+/** Intended display scale of each station icon in CSS pixels (bus = 100% baseline; sbahn 200%, ubahn 166%, tram 133%). */
+export const STATION_ICON_VISUAL_SIZES: Record<StationAreaMode, number> = { bus: 18, tram: 24, ubahn: 30, sbahn: 36 };
+
+/** Spec ratios from issue #39: sbahn 200%, ubahn 166%, tram 133%, bus 100% of the bus visual size. */
+export const STATION_ICON_SPEC_RATIOS: Record<StationAreaMode, number> = { bus: 1, tram: 4 / 3, ubahn: 5 / 3, sbahn: 2 };
+
+/** Padding around the station glyph visual size on each side, in CSS pixels. */
+export const STATION_ICON_PADDING = 11;

--- a/lib/domain/route-first/meeting-service.ts
+++ b/lib/domain/route-first/meeting-service.ts
@@ -744,7 +744,7 @@ export function runRouteFirstMeetingService(
     let normalizedJourneys: readonly RouteJourney[];
     try {
       normalizedJourneys = input.journeys.map((journey) => normalizeRouteJourney(journey));
-    } catch (error) {
+    } catch {
       return incomplete(input, "missing-coverage", enumerationEvidence);
     }
     const certifiedPathKeys = new Set<string>();
@@ -858,7 +858,7 @@ export function runRouteFirstMeetingService(
         const profiles = input.targetProfiles.filter((profile) => profile.edgeId === edge.id);
         fairRegions.push(allParticipantToleranceRegion(profiles, tolerance));
       }
-    } catch (error) {
+    } catch {
       return incomplete(input, "missing-coverage", enumerationEvidence);
     }
     const fairRegionGeometry: RouteFirstFairRegionGeometry[] = relevantEdges.map((edge) => ({ edgeId: edge.id, start: wireCoordinate(edge.start), end: wireCoordinate(edge.end) }));

--- a/lib/domain/scheduled-routing/artifact.ts
+++ b/lib/domain/scheduled-routing/artifact.ts
@@ -170,7 +170,7 @@ export function writeScheduledArtifact(path: string, artifact: ScheduledRoutingA
   const absolutePath = resolve(path);
   validateArtifactStructure(artifact);
   const { compiledArtifactId, ...identity } = artifact.provenance;
-  const { provenance: _provenance, ...core } = artifact;
+  const { provenance, ...core } = artifact;
   if (calculateScheduledContentHash(identity.feedId, identity.timeZone, identity.files) !== identity.contentHash || calculateScheduledCompiledArtifactId(core, identity) !== compiledArtifactId) {
     throw new ScheduleArtifactUnavailableError("The scheduled artifact identity does not match its contents.");
   }
@@ -186,7 +186,7 @@ export function writeScheduledArtifact(path: string, artifact: ScheduledRoutingA
     payloadSha256: sha256Bytes(payload),
     compiledArtifactId,
     summary: bundleSummary(core),
-    provenance: artifact.provenance,
+    provenance,
     compilerVersion: SCHEDULED_COMPILER_VERSION,
   };
   const directory = dirname(absolutePath);
@@ -353,7 +353,7 @@ export function loadScheduledArtifact(
   if (!isScheduledRoutingArtifact(parsed)) throw new ScheduleArtifactUnavailableError("The configured scheduled artifact failed schema validation.");
   validateArtifactStructure(parsed);
   const { compiledArtifactId, ...identity } = parsed.provenance;
-  const { provenance: _provenance, ...core } = parsed;
+  const { provenance, ...core } = parsed;
   if (calculateScheduledContentHash(identity.feedId, identity.timeZone, identity.files) !== identity.contentHash) {
     throw new ScheduleArtifactUnavailableError("The configured scheduled artifact file-hash content identity does not match its provenance.");
   }
@@ -362,7 +362,7 @@ export function loadScheduledArtifact(
   }
   validateBundleSummary(manifest.summary, core);
   validateRawArchive(parsed, options.rawArchiveBytes);
-  validateFreshness(parsed.provenance.acquisition, options.now ?? defaultLoaderNow());
+  validateFreshness(provenance.acquisition, options.now ?? defaultLoaderNow());
   const frozen = deepFreeze(parsed);
   loadedScheduledArtifacts.set(absolutePath, frozen);
   return frozen;

--- a/lib/providers/self-hosted-routing.ts
+++ b/lib/providers/self-hosted-routing.ts
@@ -147,7 +147,7 @@ export class OtpGraphqlRoutingProvider implements PointToPointRoutingProvider {
             origin: toOtpLocation(request.origin, "origin"),
             destination: toOtpLocation(request.destination, "destination"),
             dateTime: toOtpDateTime(request.departureAt),
-            modes: toOtpModes(this.config.otpProfile),
+            modes: toOtpModes(),
             first: OTP_PAGE_SIZE,
             after,
           },
@@ -995,7 +995,7 @@ function toOtpDateTime(departureAt: string): { earliestDeparture: string } {
   return { earliestDeparture: departureAt };
 }
 
-function toOtpModes(_profile: string): {
+function toOtpModes(): {
   transit: {
     access: Array<"WALK">;
     egress: Array<"WALK">;

--- a/test/workflow-guard.test.ts
+++ b/test/workflow-guard.test.ts
@@ -59,13 +59,12 @@ test("validation job runs Node 24 checks before publication", () => {
   assert.match(ciWorkflow, /name:\s*Validate Node 24 \(merge result\)/);
 });
 
-test("publish job builds and publishes both runner and compiler images with multi-platform and provenance", () => {
+test("publish job builds and publishes both runner and compiler images for linux/amd64 only with provenance", () => {
   const job = publishJob(publishWorkflow);
 
   // Runner image configuration
   assert.match(job, /images:\s*ghcr\.io\/\${{\s*steps\.owner\.outputs\.owner\s*}}\/meeet\b/);
   assert.match(job, /target:\s*runner/);
-  assert.match(job, /platforms:\s*linux\/amd64,linux\/arm64/);
   assert.match(job, /cache-from:\s*type=gha,scope=meeet-runner/);
   assert.match(job, /cache-to:\s*type=gha,mode=max,scope=meeet-runner/);
 
@@ -74,6 +73,11 @@ test("publish job builds and publishes both runner and compiler images with mult
   assert.match(job, /target:\s*artifact-compiler/);
   assert.match(job, /cache-from:\s*type=gha,scope=meeet-compiler/);
   assert.match(job, /cache-to:\s*type=gha,mode=max,scope=meeet-compiler/);
+
+  // Both runner and compiler builds target linux/amd64 as the single platform.
+  const platformMatches = job.match(/platforms:\s*[^\n]+/g);
+  assert.ok(platformMatches && platformMatches.length === 2, "both runner and compiler must declare a platforms: line");
+  assert.deepEqual(platformMatches, ["platforms: linux/amd64", "platforms: linux/amd64"]);
 
   // Shared tags and provenance settings
   const tagMatches = job.match(/type=sha,format=long,prefix=sha-/g);
@@ -84,6 +88,11 @@ test("publish job builds and publishes both runner and compiler images with mult
   // Digest summary
   assert.match(job, /MEEET_IMAGE=ghcr\.io\/\${GHCR_OWNER}\/meeet@\${RUNNER_DIGEST}/);
   assert.match(job, /MEEET_COMPILER_IMAGE=ghcr\.io\/\${GHCR_OWNER}\/meeet-artifact-compiler@\${COMPILER_DIGEST}/);
+});
+
+test("publish workflow targets linux/amd64 only and does not set up QEMU", () => {
+  assert.doesNotMatch(publishWorkflow, /linux\/arm64/, "arm64 builds must be dropped");
+  assert.doesNotMatch(publishWorkflow, /setup-qemu-action|QEMU/i, "QEMU emulation setup must be removed");
 });
 
 test("grants registry write permissions only in the publish job under least privilege", () => {


### PR DESCRIPTION
6e32341 Merge pull request #48 from TiloHeidasch/feature/22-eliminate-actions-warnings
25151c9 Merge remote-tracking branch 'origin/dev' into feature/22-eliminate-actions-warnings
d8665be Merge pull request #47 from TiloHeidasch/feature/36-remove-arm64-builds
9e7dfe2 fix(ci): eliminate GitHub Actions warnings (#22)
d2a5f36 Merge remote-tracking branch 'origin/dev' into feature/36-remove-arm64-builds
6b9bd28 docs: restore line-wrap convention after linux/amd64 wording (#36)
19df9d6 ci(ghcr): publish linux/amd64 only and drop QEMU emulation (#36)
5f55b47 Merge pull request #42 from TiloHeidasch/issue-39-icon-layer-ordering
25081a0 Merge branch 'dev' into issue-39-icon-layer-ordering
6230bcc Merge pull request #46 from TiloHeidasch/feature/ci-dev-compiler-tag
6027027 docs(ci): compiler image now published on dev pushes with dev tag
974d616 ci(ghcr): publish compiler image with dev tag on dev branch pushes
236b34e docs(ci): advisory oracle review, agent-driven dev merges, operator-only main promotion (#18) (#45)
1d85882 feat(ci): e2e compiles the schedule artifact and calculates at now + 5 min (#18) (#44)
0e9218f feat(ci): establish branch-based development and GHCR image publication (#18) (#41)
34f3e0f feat(ui): order station icons by mode with spec size hierarchy (#39)