### PR TITLE
fix(compiler): accept non-zero seconds in stop_times instead of rejecting the real MVV feed (#61)

### DIFF
--- a/lib/domain/scheduled-routing/gtfs.ts
+++ b/lib/domain/scheduled-routing/gtfs.ts
@@ -874,7 +874,11 @@ function gtfsDate(value: string, table: CsvTable, index: number): string {
   return `${value.slice(0, 4)}-${value.slice(4, 6)}-${value.slice(6, 8)}`;
 }
 
-/** Only :00 seconds are routable; the scheduled calculation is minute-aligned end to end. */
+/**
+ * The scheduled calculation is minute-aligned end to end, so sub-minute
+ * seconds are truncated to the minute instead of rejecting the row: real
+ * feeds carry non-zero seconds, but the artifact must stay minute-aligned.
+ */
 function gtfsTime(value: string, table: CsvTable, index: number, column: string): number {
   const match = /^(\d{1,3}):(\d{2}):(\d{2})$/.exec(value);
   if (!match) throw new GtfsValidationError(`${column} must use HH:MM:SS.`, table.fileName, index + 2);
@@ -882,8 +886,7 @@ function gtfsTime(value: string, table: CsvTable, index: number, column: string)
   const minutes = Number(match[2]);
   const seconds = Number(match[3]);
   if (minutes > 59 || seconds > 59 || hours > 99) throw new GtfsValidationError(`${column} is outside the supported GTFS time range.`, table.fileName, index + 2);
-  if (seconds !== 0) throw new GtfsValidationError(`${column} must use :00 seconds; the scheduled calculation is minute-aligned.`, table.fileName, index + 2);
-  return hours * 3_600 + minutes * 60 + seconds;
+  return hours * 3_600 + minutes * 60;
 }
 
 function pickupDropOff(value: string, table: CsvTable, index: number, column: string): GtfsPickupDropOffType {

--- a/scripts/fixture-schedule-transform.ts
+++ b/scripts/fixture-schedule-transform.ts
@@ -69,13 +69,13 @@ function shiftGtfsTime(value: string, shiftMinutes: number): string {
   const minutes = Number(match[2]);
   const seconds = Number(match[3]);
   // Mirror lib/domain/scheduled-routing/gtfs.ts gtfsTime, which rejects hours
-  // past 99 even though the fixture input is always two-digit, and rejects
-  // nonzero seconds because the scheduled calculation is minute-aligned.
+  // past 99 even though the fixture input is always two-digit, and truncates
+  // nonzero seconds to the minute because the scheduled calculation is
+  // minute-aligned; the shifted output is always :00.
   if (hours > 99 || minutes > 59 || seconds > 59) throw new Error(`Invalid GTFS time ${value}.`);
-  if (seconds !== 0) throw new Error(`Invalid GTFS time ${value}: seconds must be :00.`);
   const totalMinutes = hours * 60 + minutes + shiftMinutes;
   const shiftedHours = Math.floor(totalMinutes / 60);
   const shiftedMinutes = totalMinutes % 60;
   if (shiftedHours > 99) throw new Error(`Shifted GTFS time ${value} exceeds the supported 99-hour range.`);
-  return `${String(shiftedHours).padStart(2, "0")}:${String(shiftedMinutes).padStart(2, "0")}:${match[3]}`;
+  return `${String(shiftedHours).padStart(2, "0")}:${String(shiftedMinutes).padStart(2, "0")}:00`;
 }

--- a/test/scheduled-routing.test.ts
+++ b/test/scheduled-routing.test.ts
@@ -761,12 +761,20 @@ test("parseSearchStartInstant rounding is offset-invariant on spring and fall DS
   assert.equal(parseSearchStartInstant("2026-10-25T02:59:59+02:00", "Europe/Berlin").canonicalAt, "2026-10-25T01:00:00.000Z");
 });
 
-test("gtfsTime rejects nonzero seconds because the scheduled calculation is minute-aligned", () => {
+test("gtfsTime truncates nonzero seconds to the minute instead of rejecting the feed", () => {
   const nonzeroSecondsFiles: GtfsFeedFiles = {
     ...FIXTURE_FILES,
-    "stop_times.txt": FIXTURE_FILES["stop_times.txt"].replace("through,08:10:00,08:10:00,a-1,1,0,0", "through,08:10:05,08:10:05,a-1,1,0,0"),
+    "stop_times.txt": FIXTURE_FILES["stop_times.txt"]
+      .replace("through,08:10:00,08:10:00,a-1,1,0,0", "through,08:10:30,08:10:45,a-1,1,0,0")
+      .replace("through,08:20:00,08:21:00,b-1,2,0,0", "through,08:20:30,08:21:00,b-1,2,0,0"),
   };
-  assert.throws(() => importGtfsSchedule(nonzeroSecondsFiles, { acquisition: ACQUISITION }), /:00 seconds|minute-aligned/);
+  const schedule = importGtfsSchedule(nonzeroSecondsFiles, { acquisition: ACQUISITION });
+  const connection = schedule.connections.find((candidate) => candidate.tripId === "through");
+  assert.ok(connection);
+  assert.equal(connection.id, "through:0-1");
+  // 08:10:30 / 08:10:45 truncate to 08:10:00 (29400 s) and 08:20:30 to 08:20:00 (30000 s).
+  assert.equal(connection.departureTimeSeconds, 8 * 3_600 + 10 * 60);
+  assert.equal(connection.arrivalTimeSeconds, 8 * 3_600 + 20 * 60);
 });
 
 test("walkingSeconds rounds up to the next whole minute, with zero distance taking zero seconds", () => {


### PR DESCRIPTION
Closes #61

## Problem
`npm run schedule:compile:mvv` (rotation mode) fails against the current MVV feed (feedVersion 20260803): `gtfsTime()` rejected any stop_times row whose seconds are not `:00`, but the real feed carries non-zero seconds.

## Fix
- `lib/domain/scheduled-routing/gtfs.ts`: `gtfsTime()` now truncates sub-minute seconds to the minute instead of rejecting the row, keeping the `HH:MM:SS` parse, range checks, and next-day rollover behavior. The artifact stays minute-aligned per the scheduled calculation contract.
- `scripts/fixture-schedule-transform.ts`: `shiftGtfsTime` mirrors the new behavior (accepts non-zero seconds, emits `:00` output) to avoid parser contract drift.
- `test/scheduled-routing.test.ts`: regression test with non-zero seconds rows (`08:10:30`/`08:10:45`, `08:20:30`) asserting the artifact compiles and connection times truncate to minute-aligned values.

## Verification
- Focused scheduled tests: 94 pass
- `npx tsc --noEmit`, `npm run lint`, `git diff --check`: clean
- Oracle code review: approved, no remaining remarks