### PR TITLE
Consolidate calculation-progress phase vocabulary into one shared source (#26)

### DIFF
--- a/components/MeetPlanner.tsx
+++ b/components/MeetPlanner.tsx
@@ -4,12 +4,11 @@ import { useEffect, useMemo, useRef, useState, type FormEvent, type KeyboardEven
 import dynamic from "next/dynamic";
 import { validateMeetingResponse, type MeetingRequest, type MeetingResponse, type MeetingStationArea, type StationAreaMode } from "@/lib/client/meeting-response";
 import { validateStationAreaDetails, type StationAreaDetail } from "@/lib/client/station-area-details";
-import { readCalculationStream, type CalculationProgressPhase, type StationVerdict } from "@/lib/client/calculation-stream";
+import { CALCULATION_PROGRESS_PHASES, readCalculationStream, type CalculationProgressPhase, type StationVerdict } from "@/lib/client/calculation-stream";
 
 const MapLibreCanvas = dynamic(() => import("./MapLibreCanvas"), { ssr: false, loading: () => <div className="map-surface grid min-h-[430px] place-items-center rounded-[1.75rem] text-sm text-[#526057]">Preparing Munich map…</div> });
 const COLORS = ["#e85d4a", "#3d70c9"] as const;
 const PHASE_LABELS: Record<CalculationProgressPhase, string> = { "access-seeds": "Finding nearby transit access", "scheduled-routing": "Checking planned MVV journeys", "station-area-evaluation": "Comparing station areas", "validating-result": "Preparing the validated map" };
-const PHASE_ORDER: readonly CalculationProgressPhase[] = ["access-seeds", "scheduled-routing", "station-area-evaluation", "validating-result"];
 type Location = { label: string; lat: number; lng: number };
 type SearchResult = { label: string; latitude: number; longitude: number };
 type Participant = { id: "participant-1" | "participant-2"; location: Location | null };
@@ -467,8 +466,8 @@ export default function MeetPlanner({ capability }: { capability: PlannerCapabil
                   <strong className="progress-phase-label" aria-live="polite">{phase ? PHASE_LABELS[phase] : "Starting the planned calculation…"}</strong>
                 </div>
                 <ol className="progress-phases" aria-hidden="true">
-                  {PHASE_ORDER.map((item, index) => (
-                    <li key={item} className={phase ? (index < PHASE_ORDER.indexOf(phase) ? "done" : index === PHASE_ORDER.indexOf(phase) ? "active" : "") : ""}>{PHASE_LABELS[item]}</li>
+                  {CALCULATION_PROGRESS_PHASES.map((item, index) => (
+                    <li key={item} className={phase ? (index < CALCULATION_PROGRESS_PHASES.indexOf(phase) ? "done" : index === CALCULATION_PROGRESS_PHASES.indexOf(phase) ? "active" : "") : ""}>{PHASE_LABELS[item]}</li>
                   ))}
                 </ol>
                 <p className="progress-note">This is a planned MVV schedule calculation, not live transit information.</p>

--- a/e2e/meeting.spec.ts
+++ b/e2e/meeting.spec.ts
@@ -3,6 +3,7 @@ import { inflateSync } from "node:zlib";
 import http from "node:http";
 import type net from "node:net";
 import { STATION_ICON_PADDING, STATION_ICON_SPEC_RATIOS } from "../lib/client/station-icon-sizes";
+import { CALCULATION_PROGRESS_CONTRACT_VERSION, CALCULATION_PROGRESS_PHASES, type CalculationProgressPhase } from "../lib/domain/calculation-progress-contract";
 
 const MAP_STYLE = "https://tiles.openfreemap.org/styles/liberty";
 const MAP_ORIGIN = "https://tiles.openfreemap.org";
@@ -22,7 +23,7 @@ function v3Fixture(request: { contractVersion: "meeet-meeting/v3"; participants:
   const stationAreas = [
     { stationAreaId: "area-red", name: "Red area", coordinate: { latitude: 48.132, longitude: 11.555 }, mode: "sbahn" as const, classification: "red" as const, redArrivalSeconds: 1200, blueArrivalSeconds: null, fasterParticipant: "red" as const, withinSelectedTolerance: false },
     { stationAreaId: "area-fair", name: "Fair area", coordinate: { latitude: 48.132, longitude: 11.585 }, mode: "ubahn" as const, classification: "fair" as const, redArrivalSeconds: 1800, blueArrivalSeconds: 1860, fasterParticipant: "red" as const, withinSelectedTolerance: true },
-    { stationAreaId: "area-blue", name: "Blue area", coordinate: { latitude: 48.132, longitude: 11.615 }, mode: "tram" as const, classification: "blue" as const, redArrivalSeconds: null, blueArrivalSeconds: 1300, fasterParticipant: "blue" as const, withinSelectedTolerance: false },
+    { stationAreaId: "area-blue", name: "Blue area", coordinate: { latitude: 48.132, longitude: 11.615 }, mode: "tram" as const, classification: "blue" as const, redArrivalSeconds: null, blueArrivalSeconds: 1260, fasterParticipant: "blue" as const, withinSelectedTolerance: false },
     { stationAreaId: "area-unclassified", name: "Unclassified area", coordinate: { latitude: 48.14, longitude: 11.59 }, mode: "bus" as const, classification: "unclassified" as const, redArrivalSeconds: null, blueArrivalSeconds: null, fasterParticipant: null, withinSelectedTolerance: false },
   ];
   const acquisition = { sourceUrl: "https://example.test/mvv.zip", retrievedAt: "2026-08-01T00:00:00.000Z", rawArchiveByteSize: 100, rawArchiveSha256: "a".repeat(64), feedVersion: "mvv-fixture-2026-08", feedValidFrom: "2026-08-01", feedValidUntil: "2026-08-31", attribution: "Deterministic MVV fixture", officialAttribution: "MVV", officialLicense: { name: "CC BY 4.0", url: "https://creativecommons.org/licenses/by/4.0/" }, officialProvenance: { source: "feed" as const, policyId: null } };
@@ -58,13 +59,13 @@ function sseFrame(event: string, data: unknown): string {
   return `event: ${event}\ndata: ${JSON.stringify(data)}\n\n`;
 }
 
-function progressFrame(phase: string): string {
-  return sseFrame("progress", { contractVersion: "meeet-calculation-progress/v1", phase });
+function progressFrame(phase: CalculationProgressPhase): string {
+  return sseFrame("progress", { contractVersion: CALCULATION_PROGRESS_CONTRACT_VERSION, phase });
 }
 
 function verdictFrame(area: { stationAreaId: string; name: string; coordinate: { latitude: number; longitude: number }; classification: string; mode?: string }): string {
   return sseFrame("station-verdict", {
-    contractVersion: "meeet-calculation-progress/v1",
+    contractVersion: CALCULATION_PROGRESS_CONTRACT_VERSION,
     stationAreaId: area.stationAreaId,
     name: area.name,
     coordinate: area.coordinate,
@@ -74,13 +75,13 @@ function verdictFrame(area: { stationAreaId: string; name: string; coordinate: {
 }
 
 function progressStreamFrames(request?: Parameters<typeof v3Fixture>[0], outcome: "ok" | "no-access-seeds" = "ok"): string {
-  const p1 = progressFrame("access-seeds");
-  const p2 = progressFrame("scheduled-routing");
-  const p3 = progressFrame("station-area-evaluation");
+  const p1 = progressFrame(CALCULATION_PROGRESS_PHASES[0]);
+  const p2 = progressFrame(CALCULATION_PROGRESS_PHASES[1]);
+  const p3 = progressFrame(CALCULATION_PROGRESS_PHASES[2]);
   const verdicts = request
     ? v3Fixture(request, outcome).stationAreas.map(verdictFrame).join("")
     : "";
-  const p4 = progressFrame("validating-result");
+  const p4 = progressFrame(CALCULATION_PROGRESS_PHASES[3]);
   return `${p1}${p2}${p3}${verdicts}${p4}`;
 }
 function okStreamBody(request: Parameters<typeof v3Fixture>[0], outcome: "ok" | "no-access-seeds" = "ok"): string { return `${progressStreamFrames(request, outcome)}event: ref\ndata: {"calculationRef":"fixture-calculation-ref"}\n\nevent: result\ndata: ${JSON.stringify(v3Fixture(request, outcome))}\n\n`; }
@@ -439,9 +440,9 @@ test.describe("v3 Munich meeting surface", () => {
         "Cache-Control": "no-cache",
         "Connection": "keep-alive",
       });
-      res.write(progressFrame("access-seeds"));
-      res.write(progressFrame("scheduled-routing"));
-      res.write(progressFrame("station-area-evaluation"));
+      res.write(progressFrame(CALCULATION_PROGRESS_PHASES[0]));
+      res.write(progressFrame(CALCULATION_PROGRESS_PHASES[1]));
+      res.write(progressFrame(CALCULATION_PROGRESS_PHASES[2]));
       res.write(verdictFrame({ stationAreaId: "area-red", name: "Red area", coordinate: { latitude: 48.132, longitude: 11.555 }, classification: "red" }));
       res.write(verdictFrame({ stationAreaId: "area-fair", name: "Fair area", coordinate: { latitude: 48.132, longitude: 11.585 }, classification: "fair" }));
       req.on("close", () => {
@@ -482,9 +483,9 @@ test.describe("v3 Munich meeting surface", () => {
         "Cache-Control": "no-cache",
         "Connection": "keep-alive",
       });
-      res.write(progressFrame("access-seeds"));
-      res.write(progressFrame("scheduled-routing"));
-      res.write(progressFrame("station-area-evaluation"));
+      res.write(progressFrame(CALCULATION_PROGRESS_PHASES[0]));
+      res.write(progressFrame(CALCULATION_PROGRESS_PHASES[1]));
+      res.write(progressFrame(CALCULATION_PROGRESS_PHASES[2]));
       // Stream area-red initially as unclassified (a placeholder/conflicting verdict)
       res.write(verdictFrame({ stationAreaId: "area-red", name: "Red area", coordinate: { latitude: 48.132, longitude: 11.555 }, classification: "unclassified" }));
       res.write(verdictFrame({ stationAreaId: "area-fair", name: "Fair area", coordinate: { latitude: 48.132, longitude: 11.585 }, classification: "fair" }));
@@ -511,7 +512,7 @@ test.describe("v3 Munich meeting surface", () => {
           const fixture = v3Fixture(requestData);
           res.write(verdictFrame({ stationAreaId: "area-blue", name: "Blue area", coordinate: { latitude: 48.132, longitude: 11.615 }, classification: "blue" }));
           res.write(verdictFrame({ stationAreaId: "area-unclassified", name: "Unclassified area", coordinate: { latitude: 48.14, longitude: 11.59 }, classification: "unclassified" }));
-          res.write(progressFrame("validating-result"));
+          res.write(progressFrame(CALCULATION_PROGRESS_PHASES[3]));
           res.write(sseFrame("ref", { calculationRef: "fixture-calculation-ref" }));
           res.write(sseFrame("result", fixture));
           res.end();

--- a/test/meeting-stream.test.ts
+++ b/test/meeting-stream.test.ts
@@ -8,6 +8,7 @@ import {
 import { ScheduledCalculationAdmission } from "../lib/domain/scheduled-admission.ts";
 import { InMemoryStationAreaCalculationBasisCache } from "../lib/domain/station-area-details-cache.ts";
 import { FIXTURE_SCHEDULED_ACCESS_PROVIDER, FIXTURE_SCHEDULED_ARTIFACT } from "../lib/fixtures/scheduled-routing.ts";
+import { CALCULATION_PROGRESS_CONTRACT_VERSION, CALCULATION_PROGRESS_PHASES } from "../lib/domain/calculation-progress-contract.ts";
 import type { MeetingProviders } from "../lib/domain/providers.ts";
 
 const REQUEST = {
@@ -78,20 +79,15 @@ test("phases and station verdicts are emitted in order with the progress contrac
   const body = await response.text();
   const frames = parseSseFrames(body);
   const progress = frames.filter((frame) => frame.event === "progress");
-  assert.deepEqual(progress.map((frame) => JSON.parse(frame.data ?? "{}").phase), [
-    "access-seeds",
-    "scheduled-routing",
-    "station-area-evaluation",
-    "validating-result",
-  ]);
+  assert.deepEqual(progress.map((frame) => JSON.parse(frame.data ?? "{}").phase), [...CALCULATION_PROGRESS_PHASES]);
   for (const frame of progress) {
-    assert.equal(JSON.parse(frame.data ?? "{}").contractVersion, "meeet-calculation-progress/v1");
+    assert.equal(JSON.parse(frame.data ?? "{}").contractVersion, CALCULATION_PROGRESS_CONTRACT_VERSION);
   }
   const verdicts = frames.filter((frame) => frame.event === "station-verdict");
   assert.equal(verdicts.length, 3);
   for (const frame of verdicts) {
     const data = JSON.parse(frame.data ?? "{}");
-    assert.equal(data.contractVersion, "meeet-calculation-progress/v1");
+    assert.equal(data.contractVersion, CALCULATION_PROGRESS_CONTRACT_VERSION);
     assert.ok(typeof data.stationAreaId === "string" && data.stationAreaId.length > 0);
     assert.ok(typeof data.name === "string" && data.name.length > 0);
     assert.ok(typeof data.coordinate?.latitude === "number");
@@ -132,8 +128,8 @@ test("finality: verdicts are emitted strictly after station-area-evaluation phas
   const body = await response.text();
   const frames = parseSseFrames(body);
   const events = frames.map((f) => f.event ?? (f.comment ? ":comment" : "unknown"));
-  const stationAreaEvalIndex = events.findIndex((e, idx) => e === "progress" && JSON.parse(frames[idx]!.data ?? "{}").phase === "station-area-evaluation");
-  const validatingResultIndex = events.findIndex((e, idx) => e === "progress" && JSON.parse(frames[idx]!.data ?? "{}").phase === "validating-result");
+  const stationAreaEvalIndex = events.findIndex((e, idx) => e === "progress" && JSON.parse(frames[idx]!.data ?? "{}").phase === CALCULATION_PROGRESS_PHASES[2]);
+  const validatingResultIndex = events.findIndex((e, idx) => e === "progress" && JSON.parse(frames[idx]!.data ?? "{}").phase === CALCULATION_PROGRESS_PHASES[3]);
   assert.ok(stationAreaEvalIndex !== -1);
   assert.ok(validatingResultIndex !== -1);
   assert.ok(stationAreaEvalIndex < validatingResultIndex);
@@ -183,7 +179,7 @@ test("no-result request streams a terminal result event with status no-result an
   assert.equal(verdicts.length, 3);
   for (const frame of verdicts) {
     const data = JSON.parse(frame.data ?? "{}");
-    assert.equal(data.contractVersion, "meeet-calculation-progress/v1");
+    assert.equal(data.contractVersion, CALCULATION_PROGRESS_CONTRACT_VERSION);
     assert.equal(data.verdict, "unclassified");
   }
   const resultFrame = frames.find((frame) => frame.event === "result");


### PR DESCRIPTION
Closes #26

## What

Makes the `meeet-calculation-progress/v1` phase vocabulary and contract version a single source of truth in `lib/domain/calculation-progress-contract.ts`, shared by the server, the client SSE parser, the UI, and the tests.

The shared module already existed on dev (created by the #17 stream work) and the server (`lib/domain/meeting-api.ts`, `lib/domain/scheduled-routing/meeting.ts`) and client parser (`lib/client/calculation-stream.ts`) already imported from it. This PR removes the remaining re-declarations:

- `components/MeetPlanner.tsx` — deleted the local `PHASE_ORDER` (literally identical to the `CALCULATION_PROGRESS_PHASES` constant it already had access to via `@/lib/client/calculation-stream`); the progress list now iterates the shared constant.
- `e2e/meeting.spec.ts` — `progressFrame`/`verdictFrame` and all phase emissions now use `CALCULATION_PROGRESS_CONTRACT_VERSION` / `CALCULATION_PROGRESS_PHASES`; `progressFrame` is typed with `CalculationProgressPhase`.
- `test/meeting-stream.test.ts` — inline phase list and contract-version strings replaced with the shared constants.

## Constraints honored

- Shared module stays client-safe (zero imports, no server-only code, no node built-ins).
- Wire contract byte-identical: `meeet-calculation-progress/v1` and phases `access-seeds`, `scheduled-routing`, `station-area-evaluation`, `validating-result`.
- No stream behavior, event shape, or UI phase label changes.

## Pre-existing e2e fixture drift fixed (required for the e2e gate)

The Playwright suite is not run in CI (only the `scripts/e2e-calculation.mjs` smoke test), so a drift introduced by #59 ("remove seconds precision", commit 4c9e6d7) went unnoticed: the fixture's `area-blue` had `blueArrivalSeconds: 1300`, which violates the client validator's minute-aligned-seconds rule (`wholeMinuteSeconds` in `lib/client/meeting-response.ts`). 18 e2e tests were failing on dev before this branch. Changed `1300 → 1260` (21:00, still `% 60 === 0`, same classification semantics). All 27 e2e tests pass now.

## Verification

- `npm test` — 262 pass
- `npx tsc --noEmit` — clean
- `npm run lint` — zero errors
- `git diff --check` — clean
- `npm run test:e2e` — 27 pass

Reviewed by oracle (code-review skill): no blocking issues.