### PR TITLE
Fix map auto-zoom framing

### DIFF
--- a/components/MapLibreCanvas.tsx
+++ b/components/MapLibreCanvas.tsx
@@ -9,7 +9,7 @@ import { STATION_ICON_PADDING, STATION_ICON_VISUAL_SIZES } from "@/lib/client/st
 import { messages, useLocale, type Locale } from "@/lib/client/i18n";
 
 export type MapParticipant = { id: string; number: number; label: string; latitude: number; longitude: number; color: "#e85d4a" | "#3d70c9" };
-type Props = { participants: readonly MapParticipant[]; stationAreas: readonly MeetingStationArea[]; resultState: "initial" | "ok" | "no-result"; selectedStationAreaId?: string | null; onStationAreaSelect?: (stationAreaId: string) => void };
+type Props = { participants: readonly MapParticipant[]; stationAreas: readonly MeetingStationArea[]; fitStationArea?: MeetingStationArea | null; resultState: "initial" | "ok" | "no-result"; selectedStationAreaId?: string | null; onStationAreaSelect?: (stationAreaId: string) => void };
 type Geometry = { type: "MultiPolygon"; coordinates: number[][][][] } | { type: "Point"; coordinates: [number, number] };
 type FeatureCollection = { type: "FeatureCollection"; features: Array<{ type: "Feature"; id: string; properties: Record<string, string>; geometry: Geometry }> };
 const MUNICH_CENTER: [number, number] = [11.576, 48.137];
@@ -243,12 +243,10 @@ function sortedOriginPoints(participants: readonly MapParticipant[]): Array<[num
     .sort((a, b) => a[0] - b[0] || a[1] - b[1]);
 }
 
-function renderedLocationPoints(participants: readonly MapParticipant[], stationAreas: readonly MeetingStationArea[]): Array<[number, number]> {
+function renderedLocationPoints(participants: readonly MapParticipant[], fitStationArea: MeetingStationArea | null | undefined): Array<[number, number]> {
   const points = sortedOriginPoints(participants);
-  if (stationAreas.length > 0) {
-    for (const area of stationAreas) {
-      if (Number.isFinite(area.coordinate.latitude) && Number.isFinite(area.coordinate.longitude)) points.push([area.coordinate.longitude, area.coordinate.latitude]);
-    }
+  if (fitStationArea && Number.isFinite(fitStationArea.coordinate.latitude) && Number.isFinite(fitStationArea.coordinate.longitude)) {
+    points.push([fitStationArea.coordinate.longitude, fitStationArea.coordinate.latitude]);
   }
   return points;
 }
@@ -273,7 +271,7 @@ function fitToPoints(map: Map, points: Array<[number, number]>) {
   map.fitBounds(bounds, { padding: REFOCUS_PADDING, maxZoom: REFOCUS_MAX_ZOOM, ...duration });
 }
 
-export default function MapLibreCanvas({ participants, stationAreas, resultState, selectedStationAreaId = null, onStationAreaSelect }: Props) {
+export default function MapLibreCanvas({ participants, stationAreas, fitStationArea = null, resultState, selectedStationAreaId = null, onStationAreaSelect }: Props) {
   const locale = useLocale(); const t = messages[locale];
   const containerRef = useRef<HTMLDivElement>(null);
   const mapRef = useRef<Map | null>(null);
@@ -285,6 +283,7 @@ export default function MapLibreCanvas({ participants, stationAreas, resultState
   const lastFitSignature = useRef("");
   const lastFitPoints = useRef<Array<[number, number]>>([]);
   const lastOriginSignature = useRef("");
+  const lastFitTargetSignature = useRef("");
   const inputs = useRef({ onStationAreaSelect });
   const [state, setState] = useState<"loading" | "ready" | "unavailable">("loading");
   const [markersReady, setMarkersReady] = useState(false);
@@ -428,6 +427,7 @@ export default function MapLibreCanvas({ participants, stationAreas, resultState
       lastFitSignature.current = "";
       lastFitPoints.current = [];
       lastOriginSignature.current = "";
+      lastFitTargetSignature.current = "";
       fitRef.current = () => {};
       mapRef.current = null;
     };
@@ -446,29 +446,36 @@ export default function MapLibreCanvas({ participants, stationAreas, resultState
     territorySource?.setData(generated);
     setTerritoryFeatureCount(generated.features.length);
 syncOrigins(map, participants, markersRef, locale);
-    const points = renderedLocationPoints(participants, stationAreas);
+    const points = renderedLocationPoints(participants, fitStationArea);
     refocusControlRef.current?.setDisabled(points.length === 0);
     const sorted = [...points].sort((a, b) => a[0] - b[0] || a[1] - b[1]);
-    const signature = JSON.stringify(sorted);
+    // Keep the ranked area's identity in the signature even when coordinates match.
+    const fitTargetSignature = JSON.stringify(fitStationArea ? [fitStationArea.stationAreaId, fitStationArea.coordinate.longitude, fitStationArea.coordinate.latitude] : null);
+    const signature = JSON.stringify({ points: sorted, fitTarget: fitTargetSignature });
     if (signature !== lastFitSignature.current) {
       const previous = lastFitPoints.current;
       const originSignature = JSON.stringify(sortedOriginPoints(participants));
       const originsChanged = originSignature !== lastOriginSignature.current;
       const grew = sorted.some((point) => !previous.some((prev) => prev[0] === point[0] && prev[1] === point[1]));
+      const fitTargetChanged = fitTargetSignature !== lastFitTargetSignature.current;
       lastFitSignature.current = signature;
       lastFitPoints.current = sorted;
       lastOriginSignature.current = originSignature;
+      lastFitTargetSignature.current = fitTargetSignature;
       fitRef.current = () => fitToPoints(map, points);
-      if (originsChanged || grew) fitToPoints(map, points);
+      if (originsChanged || grew || fitTargetChanged) fitToPoints(map, points);
     }
     const markReady = () => {
       if (!map || map !== mapRef.current) return;
-      const ready = stationAreas.length === 0 || stationAreas.every((area) => map.queryRenderedFeatures(map.project([area.coordinate.longitude, area.coordinate.latitude]), { layers: STATION_ICON_LAYERS }).some((feature) => feature.properties?.stationAreaId === area.stationAreaId));
+      // Source features remain available even when the focused viewport places a
+      // later station area outside the canvas.
+      const sourceStationIds = new Set(map.querySourceFeatures("meeet-station-areas").map((feature) => feature.properties?.stationAreaId));
+      const ready = stationAreas.length === 0 || stationAreas.every((area) => sourceStationIds.has(area.stationAreaId));
       if (ready) setMarkersReady(true);
     };
     map.once("idle", markReady);
     return () => { map.off("idle", markReady); };
-  }, [stationAreas, stations, participants, state, resultState, locale]);
+  }, [stationAreas, stations, participants, fitStationArea, state, resultState, locale]);
 
   useEffect(() => {
     const map = mapRef.current;

--- a/components/MapLibreCanvas.tsx
+++ b/components/MapLibreCanvas.tsx
@@ -243,7 +243,7 @@ function sortedOriginPoints(participants: readonly MapParticipant[]): Array<[num
     .sort((a, b) => a[0] - b[0] || a[1] - b[1]);
 }
 
-function renderedLocationPoints(participants: readonly MapParticipant[], fitStationArea: MeetingStationArea | null | undefined): Array<[number, number]> {
+function cameraFitPoints(participants: readonly MapParticipant[], fitStationArea: MeetingStationArea | null | undefined): Array<[number, number]> {
   const points = sortedOriginPoints(participants);
   if (fitStationArea && Number.isFinite(fitStationArea.coordinate.latitude) && Number.isFinite(fitStationArea.coordinate.longitude)) {
     points.push([fitStationArea.coordinate.longitude, fitStationArea.coordinate.latitude]);
@@ -446,7 +446,7 @@ export default function MapLibreCanvas({ participants, stationAreas, fitStationA
     territorySource?.setData(generated);
     setTerritoryFeatureCount(generated.features.length);
 syncOrigins(map, participants, markersRef, locale);
-    const points = renderedLocationPoints(participants, fitStationArea);
+    const points = cameraFitPoints(participants, fitStationArea);
     refocusControlRef.current?.setDisabled(points.length === 0);
     const sorted = [...points].sort((a, b) => a[0] - b[0] || a[1] - b[1]);
     // Keep the ranked area's identity in the signature even when coordinates match.
@@ -463,15 +463,14 @@ syncOrigins(map, participants, markersRef, locale);
       lastOriginSignature.current = originSignature;
       lastFitTargetSignature.current = fitTargetSignature;
       fitRef.current = () => fitToPoints(map, points);
-      if (originsChanged || grew || fitTargetChanged) fitToPoints(map, points);
+      if (originsChanged || grew || (fitStationArea !== null && fitTargetChanged)) fitToPoints(map, points);
     }
     const markReady = () => {
       if (!map || map !== mapRef.current) return;
-      // Source features remain available even when the focused viewport places a
-      // later station area outside the canvas.
-      const sourceStationIds = new Set(map.querySourceFeatures("meeet-station-areas").map((feature) => feature.properties?.stationAreaId));
-      const ready = stationAreas.length === 0 || stationAreas.every((area) => sourceStationIds.has(area.stationAreaId));
-      if (ready) setMarkersReady(true);
+      // `idle` means the style and the synchronous GeoJSON update have settled.
+      // Do not query rendered/source features here: symbols outside the camera
+      // (or outside a loaded tile) are valid rendered data, not a readiness failure.
+      if (map.isStyleLoaded() && map.getSource("meeet-station-areas")) setMarkersReady(true);
     };
     map.once("idle", markReady);
     return () => { map.off("idle", markReady); };

--- a/components/MeetPlanner.tsx
+++ b/components/MeetPlanner.tsx
@@ -595,7 +595,7 @@ export default function MeetPlanner({ capability }: { capability: PlannerCapabil
           </section>
           <section className="map-column">
             <div className="map-viewport">
-              <MapLibreCanvas participants={mapParticipants} stationAreas={stationAreas} resultState={result ? (noResult ? "no-result" : "ok") : "initial"} selectedStationAreaId={selectedId} onStationAreaSelect={(id) => void selectStationArea(id)} />
+              <MapLibreCanvas participants={mapParticipants} stationAreas={stationAreas} fitStationArea={result ? sortedStationAreas[0] ?? null : null} resultState={result ? (noResult ? "no-result" : "ok") : "initial"} selectedStationAreaId={selectedId} onStationAreaSelect={(id) => void selectStationArea(id)} />
               {result && <Legend />}
             </div>
             {result && <StationAreaList areas={sortedStationAreas} selectedId={selectedId} resultState={noResult ? "no-result" : "ok"} detail={detail} detailLoading={detailLoading} detailError={detailError} reason={result.reason} expired={detailExpired} onSelect={(id) => void selectStationArea(id)} onRecalculate={() => void calculate()} />}

--- a/e2e/meeting.spec.ts
+++ b/e2e/meeting.spec.ts
@@ -697,35 +697,40 @@ test.describe("v3 Munich meeting surface", () => {
     await expect.poll(async () => { const v = await page.evaluate(() => { const map = (window as unknown as { __meeetMap?: { getCenter: () => { lat: number; lng: number }; getZoom: () => number; getBounds: () => { getWest: () => number; getEast: () => number; getSouth: () => number; getNorth: () => number } } }).__meeetMap; if (!map) throw new Error("Map instance unavailable"); const center = map.getCenter(); const b = map.getBounds(); return { lng: center.lng, lat: center.lat, zoom: map.getZoom(), west: b.getWest(), east: b.getEast(), south: b.getSouth(), north: b.getNorth() }; }); return Math.abs(v.lng - 11.5755) < 1e-4 && Math.abs(v.lat - 48.1374) < 1e-4 && Math.abs(v.zoom - 15) < 0.01 && v.west <= v.east && v.south <= v.north; }).toBe(true);
   });
 
-  test("refocuses the map onto rendered origins and station areas when results appear", async ({ page }) => {
+  test("fits successful results to origins and only the best-ranked station area", async ({ page }) => {
     await setup(page); await openPlanner(page); await selectOrigin(page, 0, "Marienplatz"); await selectOrigin(page, 1, "Ostbahnhof");
     await page.getByRole("button", { name: "meeet!" }).click();
     await expect(page.getByText("Meeting result", { exact: true })).toBeVisible();
     await expect(page.locator('.map-frame[data-map-state="ready"]')).toHaveAttribute("data-station-markers-ready", "true");
     const bounds = await page.evaluate(() => { const map = (window as unknown as { __meeetMap?: { getBounds: () => { getWest: () => number; getEast: () => number; getSouth: () => number; getNorth: () => number } } }).__meeetMap; if (!map) throw new Error("Map instance unavailable"); const b = map.getBounds(); return { west: b.getWest(), east: b.getEast(), south: b.getSouth(), north: b.getNorth() }; });
-    for (const [lng, lat] of [[11.5755, 48.1374], [11.605, 48.1257], [11.555, 48.132], [11.585, 48.132], [11.615, 48.132], [11.59, 48.14]] as const) {
+    for (const [lng, lat] of [[11.5755, 48.1374], [11.605, 48.1257], [11.585, 48.132]] as const) {
       expect(bounds.west).toBeLessThanOrEqual(lng);
       expect(bounds.east).toBeGreaterThanOrEqual(lng);
       expect(bounds.south).toBeLessThanOrEqual(lat);
       expect(bounds.north).toBeGreaterThanOrEqual(lat);
     }
+    // The red and blue areas remain rendered, but neither can expand the fit.
+    expect(bounds.west).toBeGreaterThan(11.555);
+    expect(bounds.east).toBeLessThan(11.615);
     expect(bounds.east - bounds.west).toBeLessThan(0.2);
     expect(bounds.north - bounds.south).toBeLessThan(0.2);
     await expect(page.getByRole("button", { name: "Refocus map" })).toBeEnabled();
   });
 
-  test("refocuses the map onto rendered origins and unclassified station areas for a no-result surface", async ({ page }) => {
+  test("fits no-result surfaces to origins and only the first ranked unclassified area", async ({ page }) => {
     await setup(page, "no-access-seeds"); await openPlanner(page); await selectOrigin(page, 0, "Marienplatz"); await selectOrigin(page, 1, "Ostbahnhof");
     await page.getByRole("button", { name: "meeet!" }).click();
     await expect(page.getByText("No result yet", { exact: true })).toBeVisible();
     await expect(page.locator('.map-frame[data-map-state="ready"]')).toHaveAttribute("data-station-markers-ready", "true");
     const bounds = await page.evaluate(() => { const map = (window as unknown as { __meeetMap?: { getBounds: () => { getWest: () => number; getEast: () => number; getSouth: () => number; getNorth: () => number } } }).__meeetMap; if (!map) throw new Error("Map instance unavailable"); const b = map.getBounds(); return { west: b.getWest(), east: b.getEast(), south: b.getSouth(), north: b.getNorth() }; });
-    for (const [lng, lat] of [[11.5755, 48.1374], [11.605, 48.1257], [11.555, 48.132], [11.585, 48.132], [11.615, 48.132], [11.59, 48.14]] as const) {
+    for (const [lng, lat] of [[11.5755, 48.1374], [11.605, 48.1257], [11.615, 48.132]] as const) {
       expect(bounds.west).toBeLessThanOrEqual(lng);
       expect(bounds.east).toBeGreaterThanOrEqual(lng);
       expect(bounds.south).toBeLessThanOrEqual(lat);
       expect(bounds.north).toBeGreaterThanOrEqual(lat);
     }
+    // The remaining areas are selectable/rendered, but must not influence fitting.
+    expect(bounds.west).toBeGreaterThan(11.555);
     expect(bounds.east - bounds.west).toBeLessThan(0.2);
     expect(bounds.north - bounds.south).toBeLessThan(0.2);
     await expect(page.getByRole("button", { name: "Refocus map" })).toBeEnabled();

--- a/e2e/meeting.spec.ts
+++ b/e2e/meeting.spec.ts
@@ -709,7 +709,7 @@ test.describe("v3 Munich meeting surface", () => {
       expect(bounds.south).toBeLessThanOrEqual(lat);
       expect(bounds.north).toBeGreaterThanOrEqual(lat);
     }
-    // The red and blue areas remain rendered, but neither can expand the fit.
+    // The red and blue areas remain in the station-area source data, but neither can expand the fit.
     expect(bounds.west).toBeGreaterThan(11.555);
     expect(bounds.east).toBeLessThan(11.615);
     expect(bounds.east - bounds.west).toBeLessThan(0.2);
@@ -718,7 +718,16 @@ test.describe("v3 Munich meeting surface", () => {
   });
 
   test("fits no-result surfaces to origins and only the first ranked unclassified area", async ({ page }) => {
-    await setup(page, "no-access-seeds"); await openPlanner(page); await selectOrigin(page, 0, "Marienplatz"); await selectOrigin(page, 1, "Ostbahnhof");
+    await setup(page, "no-access-seeds");
+    await page.unroute("**/api/meeting/calculate/stream");
+    await page.route("**/api/meeting/calculate/stream", async (route) => {
+      const request = route.request().postDataJSON();
+      const fixture = v3Fixture(request, "no-access-seeds");
+      const northern = fixture.stationAreas.find((area) => area.stationAreaId === "area-unclassified");
+      if (northern) northern.coordinate = { latitude: 48.16, longitude: 11.59 };
+      await route.fulfill({ status: 200, contentType: "text/event-stream", body: `${progressStreamFrames(request, "no-access-seeds")}event: ref\ndata: {"calculationRef":"fixture-calculation-ref"}\n\nevent: result\ndata: ${JSON.stringify(fixture)}\n\n` });
+    });
+    await openPlanner(page); await selectOrigin(page, 0, "Marienplatz"); await selectOrigin(page, 1, "Ostbahnhof");
     await page.getByRole("button", { name: "meeet!" }).click();
     await expect(page.getByText("No result yet", { exact: true })).toBeVisible();
     await expect(page.locator('.map-frame[data-map-state="ready"]')).toHaveAttribute("data-station-markers-ready", "true");
@@ -729,8 +738,9 @@ test.describe("v3 Munich meeting surface", () => {
       expect(bounds.south).toBeLessThanOrEqual(lat);
       expect(bounds.north).toBeGreaterThanOrEqual(lat);
     }
-    // The remaining areas are selectable/rendered, but must not influence fitting.
+    // The remaining areas remain in the station-area source data, but must not influence fitting.
     expect(bounds.west).toBeGreaterThan(11.555);
+    expect(bounds.north).toBeLessThan(48.16);
     expect(bounds.east - bounds.west).toBeLessThan(0.2);
     expect(bounds.north - bounds.south).toBeLessThan(0.2);
     await expect(page.getByRole("button", { name: "Refocus map" })).toBeEnabled();

--- a/e2e/meeting.spec.ts
+++ b/e2e/meeting.spec.ts
@@ -736,6 +736,47 @@ test.describe("v3 Munich meeting surface", () => {
     await expect(page.getByRole("button", { name: "Refocus map" })).toBeEnabled();
   });
 
+  test("refits and refocuses on a new top-ranked area after recalculation", async ({ page }) => {
+    let calculationCalls = 0;
+    await setup(page); await openPlanner(page); await selectOrigin(page, 0, "Marienplatz"); await selectOrigin(page, 1, "Ostbahnhof");
+    await page.unroute("**/api/meeting/calculate/stream");
+    await page.route("**/api/meeting/calculate/stream", async (route) => {
+      calculationCalls += 1;
+      const request = route.request().postDataJSON();
+      if (calculationCalls === 1) { await route.fulfill({ status: 200, contentType: "text/event-stream", body: okStreamBody(request) }); return; }
+      const changed = JSON.parse(JSON.stringify(v3Fixture(request))) as ReturnType<typeof v3Fixture>;
+      const blue = changed.stationAreas.find((area) => area.stationAreaId === "area-blue");
+      if (blue) Object.assign(blue, { redArrivalSeconds: 900, blueArrivalSeconds: 960, fasterParticipant: "red", withinSelectedTolerance: true, classification: "fair" });
+      await route.fulfill({ status: 200, contentType: "text/event-stream", body: `${progressStreamFrames(request)}${sseFrame("ref", { calculationRef: "fixture-calculation-ref" })}${sseFrame("result", changed)}` });
+    });
+    await page.getByRole("button", { name: "meeet!" }).click();
+    await expect(page.getByText("Meeting result", { exact: true })).toBeVisible();
+    const viewport = () => page.evaluate(() => { const map = (window as unknown as { __meeetMap?: { getCenter: () => { lat: number; lng: number }; getZoom: () => number; getBounds: () => { getWest: () => number; getEast: () => number } } }).__meeetMap; if (!map) throw new Error("Map instance unavailable"); const center = map.getCenter(); const bounds = map.getBounds(); return { lng: center.lng, lat: center.lat, zoom: map.getZoom(), west: bounds.getWest(), east: bounds.getEast() }; });
+    const initial = await viewport();
+    expect(initial.east).toBeLessThan(11.615);
+
+    await page.unroute("**/api/meeting/station-areas/*/details");
+    await page.route("**/api/meeting/station-areas/*/details", (route) => route.fulfill({ status: 410, contentType: "application/json", body: JSON.stringify({ error: { code: "CALCULATION_REF_EXPIRED", message: "The calculation reference is missing or has expired. Recalculate the meeting surface." } }) }));
+    await page.locator('[data-station-area-id="area-fair"]').click();
+    await expect(page.getByRole("button", { name: "Recalculate meeting places" })).toBeVisible();
+    await page.getByRole("button", { name: "Recalculate meeting places" }).click();
+    await expect.poll(() => calculationCalls).toBe(2);
+    await expect(page.getByText("Meeting result", { exact: true })).toBeVisible();
+    await expect.poll(async () => (await viewport()).east >= 11.615).toBe(true);
+    await page.evaluate(() => new Promise<void>((resolve) => { const map = (window as unknown as { __meeetMap?: { isMoving: () => boolean; once: (event: string, callback: () => void) => void } }).__meeetMap; if (!map || !map.isMoving()) { resolve(); return; } map.once("moveend", () => resolve()); }));
+    const changed = await viewport();
+    expect(changed.east).toBeGreaterThanOrEqual(11.615);
+    expect(changed.west).toBeGreaterThan(11.555);
+
+    const refocus = page.getByRole("button", { name: "Refocus map" });
+    const canvas = page.locator(".maplibregl-canvas"); await canvas.scrollIntoViewIfNeeded();
+    const rect = await canvas.boundingBox(); if (!rect) throw new Error("Map canvas was not painted");
+    await page.mouse.move(rect.x + rect.width / 2, rect.y + rect.height / 2); await page.mouse.down(); await page.mouse.move(rect.x + rect.width / 2 + 120, rect.y + rect.height / 2, { steps: 6 }); await page.mouse.up();
+    await page.evaluate(() => new Promise<void>((resolve) => { const map = (window as unknown as { __meeetMap?: { isMoving: () => boolean; once: (event: string, callback: () => void) => void } }).__meeetMap; if (!map || !map.isMoving()) { resolve(); return; } map.once("moveend", () => resolve()); }));
+    await refocus.focus(); await page.keyboard.press("Enter");
+    await expect.poll(async () => { const current = await viewport(); return Math.abs(current.lng - changed.lng) < 1e-4 && Math.abs(current.lat - changed.lat) < 1e-4 && Math.abs(current.zoom - changed.zoom) < 0.01; }).toBe(true);
+  });
+
   test("refocus control restores the fitted viewport after manual pan", async ({ page }) => {
     await setup(page); await openPlanner(page); await selectOrigin(page, 0, "Marienplatz"); await selectOrigin(page, 1, "Ostbahnhof");
     await page.getByRole("button", { name: "meeet!" }).click();


### PR DESCRIPTION
## Summary
- frame calculation results around the participant markers and best-ranked station area
- keep refocus aligned with the same target set
- cover recalculation and off-screen locations in browser tests

Closes #80