### PR TITLE
perf(scheduled): cache station-area catalogs

### DIFF
--- a/docs/profiling/calculation-baseline.md
+++ b/docs/profiling/calculation-baseline.md
@@ -1,22 +1,31 @@
-# Calculation profiling baseline (issue #72)
+# Calculation profiling baseline (issues #72 and #90)
 
-Status: baseline recorded 2026-08-20.
+Status: historical v1 baseline recorded 2026-08-20; the harness now emits v2.
 
 ## Purpose
 
-A reproducible way to measure a full scheduled meeting calculation end-to-end
-on the real MVV feed, and an evidence-based picture of where the time goes.
-Every later optimization ticket must land with measured before/after evidence
-(ADR 0003 requires profiling before and after). The performance goal is a full
-calculation below 15 s; the current baseline is ~33 s.
+A reproducible way to measure a full scheduled meeting calculation on the real
+MVV feed, and an evidence-based picture of where the time goes. Every later
+optimization ticket must land with measured before/after evidence (ADR 0003
+requires profiling before and after). The performance goal is a full
+calculation below 15 s; the historical v1 baseline is ~33 s.
 
 ## How to run
 
-The harness is `scripts/profile-scheduled-calculation.ts`. It runs one cold
-calculation per process: artifact load, access seeds (live MVG nearby),
-station-area catalog, routing-window materialization, both participant scans,
-participant surfaces, station-area evaluation, response build, validation, and
-serialization.
+The parent harness is `scripts/profile-scheduled-calculation.ts`, and its
+single-sample worker is
+`scripts/profile-scheduled-calculation-worker.ts`. The parent launches three
+sequential, fresh Node 24 child processes. Each child loads the same artifact
+path exactly once, records its `compiledArtifactId`, then measures one first
+request followed immediately by one warm request against that same immutable
+artifact object. Both requests are strictly validated with the catalog carried
+by their own `calculateScheduledMeetingWithBasis` result.
+
+Those three children are deliberately uninstrumented and are the only samples
+used for v2 timing, stage, and heap medians. If either diagnostic flag is
+requested, the parent launches one separate fourth child/pair after the timing
+children. That diagnostic pair is excluded from every timing/stage/heap
+aggregate and is reported only under `diagnostics`.
 
 Requirements:
 
@@ -32,43 +41,82 @@ Commands:
 
 ```sh
 npm run profile:calculation            # timing + heap deltas, JSON report
-npm run profile:calculation:cpu        # + profiles/cpu-calculation-*.cpuprofile
-npm run profile:calculation -- --heap-snapshots   # + per-stage heap snapshots
+npm run profile:calculation:cpu        # + one representative child/pair CPU profile
+npm run profile:calculation -- --heap-snapshots   # + one post-pair heap snapshot
 ```
 
-Output contract: the JSON report is written to
+Output contract: the aggregate JSON report is written to
 `profiles/report-<compiledArtifactId[:12]>-<timestamp>.json` and its path is
 printed to stdout; a ranked timing table goes to stderr. Exit codes:
-0 = success, 1 = calculation or validation failure, 2 = unsupported Node
-major. `profiles/` is gitignored.
+0 = success, 1 = calculation, validation, or child-process failure, 2 =
+unsupported Node major. `profiles/` is gitignored. The aggregate report uses
+`contractVersion: "meeet-calculation-profile/v2"` and
+`schema: "fresh-process-paired-first-warm/v1"`.
 
-The CPU profile covers the profiled window (profiler start just before artifact
-load through profiler stop just after serialization) via `node:inspector`, so
-tsx/loader startup is not included. It is approximately the measured window; the
-small difference is profiler start/stop overhead outside the measured stages.
-Heap snapshots are written at stage boundaries; snapshot write time is
-reported as separate `heap-snapshot:<stage>` rows so stage timings stay clean.
+The request timer starts after child startup, module loading, request parsing,
+and artifact loading. It ends after the calculation, strict validation, and
+response serialization. Child startup and artifact load are reported
+separately and are not included in first/warm request medians.
+
+`requestTimings.firstRequestMedianMs` is the median of three true
+fresh-process first requests; `warmRequestMedianMs` is the median of the three
+immediately subsequent requests in those same child processes. The report also
+contains the canonical parsed v3 `request`, the access-provider descriptor and
+per-child `accessProviderSamples`, process IDs, artifact IDs, artifact-load
+measurements, request-stage medians, validation results, and paired request
+summaries. The parent rejects any sample whose artifact path/identity, parsed
+request, or access-provider provenance differs from the others. The principal
+v2 fields are `request`, `accessProvider`, `accessProviderSamples`,
+`artifact.sampleCompiledArtifactIds`, `artifactLoad`, `requestTimings`,
+`stages.firstRequest`, `stages.warmRequest`, `validation.requests`, and
+`diagnostics`.
+
+The aggregate `accessProvider` is the stable descriptor identity; its volatile
+per-child provenance retrieval timestamp is represented as
+`<per-child-process>`. The raw descriptors observed by each child remain in
+`accessProviderSamples` for auditability.
+
+With `--inspector-cpu`, the separate fourth diagnostic child is CPU-profiled.
+That child starts `node:inspector` after artifact load and immediately before
+its first request, and stops it after the warm request timer ends; CPU-profile
+write I/O is outside both request measurements. The resulting profile covers
+one representative diagnostic first/warm pair, not child startup or any timing
+sample.
+
+With `--heap-snapshots`, the separate fourth diagnostic child writes one
+representative snapshot after its warm request has completed (and after
+CPU-profile stop, if enabled). No stage or request performs snapshot I/O, so
+snapshot writing cannot alter timing-sample medians.
 
 ## Before/after protocol
 
 For every optimization ticket:
 
 1. Check out the target commit, compile the real feed if the artifact is
-   missing or stale (`npm run schedule:compile:mvv`), and record the
-   `compiledArtifactId` from the report.
-2. Run the harness at least 3 times in fresh processes and take the median of
-   each stage. Use the same fixed request (see below) and the same artifact.
-3. Record the ranked stage table and the total in the ticket.
+   missing or stale (`npm run schedule:compile:mvv`), and record the shared
+   `compiledArtifactId` from the v2 report.
+2. Run the harness once. It creates three fresh Node 24 child processes and
+   takes first/warm medians from paired requests in those children. Use the
+   same fixed request (see below) and the same artifact path.
+3. Record the v2 first/warm medians and ranked first/warm stage tables in the
+   ticket.
 4. Implement the change, then repeat steps 1-3 on the same artifact identity.
-5. Attribute the win: report the per-stage delta, not just the total.
+5. Attribute the win: report the per-stage and first/warm deltas, not just a
+   single total.
 
-The fixed profile request is hard-coded in the harness: red
+The fixed profile request is hard-coded in the worker: red
 (48.1374, 11.5755) / blue (48.14, 11.57), tolerance 10%, change time medium,
 `searchStartAt = 2026-08-11T08:05:00+02:00` (a weekday morning inside the
 artifact's routable coverage). Changing the request invalidates the baseline
 comparison.
 
-## Current baseline (2026-08-20)
+## Historical v1 single-cold-request baseline (2026-08-20)
+
+The table below is the old v1 baseline and is retained for historical
+comparison. It is not a v2 first-request or warm-request result: v1 measured a
+single cold request per run in a fresh process. Do not compare its `Total`
+directly to either v2 request median without accounting for the protocol
+change.
 
 Artifact: `c904767465cb…` (feed `20260803`, service range 2026-08-01..
 2026-10-31, 9,313 station areas, 2,075,789 connections). Node 24.19.0.
@@ -194,14 +242,15 @@ is retained for the scan. Not a priority.
 Network-bound MVG nearby calls; not an optimization target (external
 dependency, and the guardrails forbid substituting seed resolution).
 
-## Profile artifacts
+## Historical v1 profile artifacts
 
-The 2026-08-20 baseline artifacts live in `profiles/` (gitignored):
+The 2026-08-20 v1 baseline artifacts live in `profiles/` (gitignored):
 
 - `cpu-calculation-2026-08-20T15-40-30.239Z.cpuprofile` — calculation-window
   CPU profile (34,921 samples).
-- `heap-<stage>.heapsnapshot` — one snapshot per pipeline stage boundary
-  (heap grows from ~1.2 GB after artifact load to ~1.5 GB during routing).
+- `heap-<stage>.heapsnapshot` — one snapshot per pipeline stage boundary in
+  the old v1 harness (heap grows from ~1.2 GB after artifact load to ~1.5 GB
+  during routing). The v2 harness writes at most one post-pair snapshot.
 
 Analyze the CPU profile with any DevTools/`node --prof-process`-compatible
 tool. Note that tsx compiles each module to a single line, so function

--- a/lib/domain/scheduled-routing/surface.ts
+++ b/lib/domain/scheduled-routing/surface.ts
@@ -1,5 +1,6 @@
 import "server-only";
 
+import { getOrCreateProcessValue } from "../process-registry.ts";
 import { freezeEnvelope } from "./freeze.ts";
 import { isWithinOfficialMunichBoundary } from "../boundary.ts";
 import {
@@ -29,6 +30,21 @@ import {
 import { compareScheduledIds } from "./gtfs.ts";
 
 const STATION_AREA_CHECKPOINT = 32;
+
+interface ScheduledStationAreaCatalogCache {
+  catalogs: WeakMap<ScheduledRoutingArtifact, ScheduledStationAreaCatalog>;
+}
+
+const scheduledStationAreaCatalogCache = getOrCreateProcessValue(
+  Symbol.for("meeet.scheduled-station-area-catalog-cache/v1"),
+  () => ({ catalogs: new WeakMap<ScheduledRoutingArtifact, ScheduledStationAreaCatalog>() }),
+  isScheduledStationAreaCatalogCache,
+);
+
+/** Clear the process-wide catalog cache for deterministic cold-path measurements. */
+export function clearScheduledStationAreaCatalogCache(): void {
+  scheduledStationAreaCatalogCache.catalogs = new WeakMap<ScheduledRoutingArtifact, ScheduledStationAreaCatalog>();
+}
 
 /** Calculate a two-participant scheduled arrival surface from station seeds. */
 export function calculateScheduledSurface(input: ScheduledSurfaceInput): ScheduledSurfaceResult {
@@ -113,6 +129,13 @@ export function buildScheduledStationAreaCatalog(
   schedule: ScheduledRoutingArtifact,
   deadlineCheck?: ScheduledDeadlineCheck,
 ): ScheduledStationAreaCatalog {
+  const cached = scheduledStationAreaCatalogCache.catalogs.get(schedule);
+  if (cached !== undefined) {
+    // Keep the first non-empty artifact iteration's immediate checkpoint on a
+    // cache hit so deadline behavior is unchanged by the optimization.
+    if (schedule.stationAreas.length > 0) deadlineCheck?.("station-areas");
+    return cached;
+  }
   const entries: ScheduledStationAreaCatalogEntry[] = [];
   const areas = [...schedule.stationAreas].sort((left, right) => compareScheduledIds(left.id, right.id));
   for (let index = 0; index < areas.length; index += 1) {
@@ -121,7 +144,9 @@ export function buildScheduledStationAreaCatalog(
     if (area === undefined || !isWithinOfficialMunichBoundary(area.coordinate)) continue;
     entries.push({ stationAreaId: area.id, name: area.name, coordinate: area.coordinate, mode: area.mode });
   }
-  return deepFreeze({ entries });
+  const catalog = deepFreeze({ entries });
+  scheduledStationAreaCatalogCache.catalogs.set(schedule, catalog);
+  return catalog;
 }
 
 export function createStationAreaCandidates(
@@ -291,4 +316,9 @@ function deepFreeze<T>(value: T): T {
     Object.freeze(value);
   }
   return value;
+}
+
+function isScheduledStationAreaCatalogCache(value: unknown): value is ScheduledStationAreaCatalogCache {
+  return typeof value === "object" && value !== null &&
+    (value as { catalogs?: unknown }).catalogs instanceof WeakMap;
 }

--- a/scripts/profile-scheduled-calculation-protocol.ts
+++ b/scripts/profile-scheduled-calculation-protocol.ts
@@ -1,0 +1,464 @@
+import type { ProviderDescriptor } from "../lib/domain/types.ts";
+import type { ScheduledMeetingRequest } from "../lib/validation/meeting-v3.ts";
+
+export const PROFILE_SAMPLE_COUNT = 3;
+export const EXPECTED_CALCULATION_STAGES = [
+  "access-seeds",
+  "station-area-catalog",
+  "routing-window",
+  "scan-red",
+  "scan-blue",
+  "participant-surfaces",
+  "station-area-evaluation",
+  "response-build",
+] as const;
+
+type RequestKind = "first" | "warm";
+
+export interface RequestMeasurement {
+  readonly sample: number;
+  readonly requestKind: RequestKind;
+  readonly elapsedMs: number;
+  readonly calculationElapsedMs: number;
+  readonly validationElapsedMs: number;
+  readonly serializationElapsedMs: number;
+  readonly heapDeltaBytes: number;
+  readonly status: "ok" | "no-result";
+  readonly reason: "no-access-seeds" | "no-reachable-stations" | null;
+  readonly validationSuccess: boolean;
+  readonly validationIssues: readonly unknown[] | null;
+  readonly serializedByteLength: number;
+  readonly stationAreaCatalogEntryCount: number;
+}
+
+export interface StageMeasurement {
+  readonly stage: string;
+  readonly requestKind: RequestKind;
+  readonly elapsedMs: number;
+  readonly heapDeltaBytes: number;
+}
+
+export interface ChildProfileReport {
+  readonly contractVersion: "meeet-calculation-profile-child/v2";
+  readonly nodeVersion: string;
+  readonly processId: number;
+  readonly diagnostic: boolean;
+  readonly request: ScheduledMeetingRequest;
+  readonly accessProvider: ProviderDescriptor;
+  readonly artifact: {
+    readonly path: string;
+    readonly compiledArtifactId: string;
+    readonly feedId: string;
+    readonly serviceDateRange: { readonly firstDate: string; readonly lastDate: string };
+    readonly stationAreaCount: number;
+    readonly connectionCount: number;
+  };
+  readonly artifactLoad: {
+    readonly elapsedMs: number;
+    readonly heapDeltaBytes: number;
+  };
+  readonly firstRequest: RequestMeasurement;
+  readonly warmRequest: RequestMeasurement;
+  readonly stages: readonly StageMeasurement[];
+  readonly cpuProfilePath: string | null;
+  readonly heapSnapshotPath: string | null;
+}
+
+export interface ChildRunRequest {
+  readonly sample: number;
+  readonly diagnostic: boolean;
+  readonly cpuProfile: boolean;
+  readonly heapSnapshots: boolean;
+}
+
+export interface ChildLaunch {
+  readonly command: string;
+  readonly args: readonly string[];
+  readonly request: ChildRunRequest;
+  readonly outputPath: string;
+}
+
+export interface ProfileSample {
+  readonly sample: number;
+  readonly report: ChildProfileReport;
+}
+
+export interface ProfileCollection {
+  readonly timingSamples: readonly ProfileSample[];
+  readonly diagnosticSample: ProfileSample | null;
+}
+
+export interface AggregateProfileReport {
+  readonly contractVersion: "meeet-calculation-profile/v2";
+  readonly schema: "fresh-process-paired-first-warm/v1";
+  readonly semantics: {
+    readonly sampleCount: number;
+    readonly childProcessPerSample: true;
+    readonly artifactLoadPerChild: true;
+    readonly requestTimer: string;
+    readonly firstRequest: string;
+    readonly warmRequest: string;
+  };
+  readonly nodeVersion: string;
+  readonly request: ScheduledMeetingRequest;
+  readonly accessProvider: ProviderDescriptor;
+  readonly accessProviderSamples: readonly ProviderDescriptor[];
+  readonly artifact: ChildProfileReport["artifact"] & { readonly sampleCompiledArtifactIds: readonly string[] };
+  readonly requestTimings: {
+    readonly sampleCount: number;
+    readonly firstRequestMedianMs: number;
+    readonly warmRequestMedianMs: number;
+    readonly firstRequest: RequestAggregate;
+    readonly warmRequest: RequestAggregate;
+    readonly samples: readonly unknown[];
+  };
+  readonly artifactLoad: {
+    readonly sampleCount: number;
+    readonly medianElapsedMs: number;
+    readonly medianHeapDeltaBytes: number;
+  };
+  readonly stages: {
+    readonly firstRequest: readonly StageAggregate[];
+    readonly warmRequest: readonly StageAggregate[];
+  };
+  readonly response: {
+    readonly status: "ok" | "no-result";
+    readonly reason: "no-access-seeds" | "no-reachable-stations" | null;
+    readonly stationAreaCount: number;
+    readonly serializedByteLength: number;
+  };
+  readonly validation: {
+    readonly success: boolean;
+    readonly requests: readonly unknown[];
+  };
+  readonly diagnostics: {
+    readonly sample: number;
+    readonly childProcessId: number;
+    readonly nodeVersion: string;
+    readonly compiledArtifactId: string;
+    readonly cpuProfilePath: string | null;
+    readonly heapSnapshotPath: string | null;
+    readonly firstRequest: RequestMeasurement;
+    readonly warmRequest: RequestMeasurement;
+  } | null;
+}
+
+export interface RequestAggregate {
+  readonly sampleCount: number;
+  readonly medianElapsedMs: number;
+  readonly medianCalculationElapsedMs: number;
+  readonly medianValidationElapsedMs: number;
+  readonly medianSerializationElapsedMs: number;
+  readonly medianHeapDeltaBytes: number;
+}
+
+export interface StageAggregate {
+  readonly stage: string;
+  readonly sampleCount: number;
+  readonly medianElapsedMs: number;
+  readonly medianHeapDeltaBytes: number;
+}
+
+export function buildWorkerLaunch(options: {
+  readonly nodePath: string;
+  readonly tsxCliPath: string;
+  readonly workerPath: string;
+  readonly outputPath: string;
+  readonly request: ChildRunRequest;
+}): ChildLaunch {
+  const args = ["--conditions=react-server", options.tsxCliPath, options.workerPath, "--sample", String(options.request.sample), "--output", options.outputPath];
+  if (options.request.diagnostic) args.push("--diagnostic");
+  if (options.request.cpuProfile) args.push("--inspector-cpu");
+  if (options.request.heapSnapshots) args.push("--heap-snapshots");
+  return { command: options.nodePath, args, request: options.request, outputPath: options.outputPath };
+}
+
+export function collectProfileSamples(options: {
+  readonly cpuProfile: boolean;
+  readonly heapSnapshots: boolean;
+  readonly runChild: (request: ChildRunRequest) => unknown;
+}): ProfileCollection {
+  const timingSamples: ProfileSample[] = [];
+  for (let sample = 1; sample <= PROFILE_SAMPLE_COUNT; sample += 1) {
+    const request: ChildRunRequest = { sample, diagnostic: false, cpuProfile: false, heapSnapshots: false };
+    const report = validateChildProfileReport(options.runChild(request));
+    validateSampleReport(report, request);
+    timingSamples.push({ sample, report });
+  }
+  const diagnosticSample = options.cpuProfile || options.heapSnapshots
+    ? (() => {
+        const request: ChildRunRequest = {
+          sample: PROFILE_SAMPLE_COUNT + 1,
+          diagnostic: true,
+          cpuProfile: options.cpuProfile,
+          heapSnapshots: options.heapSnapshots,
+        };
+        const report = validateChildProfileReport(options.runChild(request));
+        validateSampleReport(report, request);
+        return { sample: request.sample, report };
+      })()
+    : null;
+  const allSamples = diagnosticSample === null ? timingSamples : [...timingSamples, diagnosticSample];
+  validateStableEvidence(allSamples);
+  return { timingSamples, diagnosticSample };
+}
+
+export function validateChildProfileReport(value: unknown): ChildProfileReport {
+  if (!isRecord(value) || value.contractVersion !== "meeet-calculation-profile-child/v2" ||
+    typeof value.nodeVersion !== "string" || Number(value.nodeVersion.split(".")[0]) !== 24 ||
+    !isPositiveSafeInteger(value.processId) || typeof value.diagnostic !== "boolean" ||
+    !isCanonicalRequest(value.request) || !isAccessProviderDescriptor(value.accessProvider) ||
+    !isArtifact(value.artifact) || !isArtifactLoad(value.artifactLoad) ||
+    !isRequestMeasurement(value.firstRequest) || !isRequestMeasurement(value.warmRequest) ||
+    !isStageList(value.stages) || !isNullableString(value.cpuProfilePath) || !isNullableString(value.heapSnapshotPath)) {
+    throw new Error("The profiling child report is malformed.");
+  }
+  return value as unknown as ChildProfileReport;
+}
+
+export function aggregateProfile(collection: ProfileCollection): AggregateProfileReport {
+  const samples = collection.timingSamples;
+  if (samples.length !== PROFILE_SAMPLE_COUNT) throw new Error("Exactly three timing samples are required for v2 aggregation.");
+  const representative = samples[0];
+  if (representative === undefined) throw new Error("The profiling collection is empty.");
+  const firstRequests = samples.map((sample) => sample.report.firstRequest);
+  const warmRequests = samples.map((sample) => sample.report.warmRequest);
+  const allRequests = [...firstRequests, ...warmRequests];
+  const report: AggregateProfileReport = {
+    contractVersion: "meeet-calculation-profile/v2",
+    schema: "fresh-process-paired-first-warm/v1",
+    semantics: {
+      sampleCount: PROFILE_SAMPLE_COUNT,
+      childProcessPerSample: true,
+      artifactLoadPerChild: true,
+      requestTimer: "after-child-startup-and-artifact-load-through-strict-validation-and-response-serialization",
+      firstRequest: "first-calculation-after-artifact-load-in-a-fresh-child-process",
+      warmRequest: "immediately-subsequent-calculation-in-the-same-child-and-with-the-same-artifact-object",
+    },
+    nodeVersion: representative.report.nodeVersion,
+    request: representative.report.request,
+    accessProvider: canonicalizeAccessProviderDescriptor(representative.report.accessProvider),
+    accessProviderSamples: samples.map((sample) => sample.report.accessProvider),
+    artifact: {
+      ...representative.report.artifact,
+      sampleCompiledArtifactIds: samples.map((sample) => sample.report.artifact.compiledArtifactId),
+    },
+    requestTimings: {
+      sampleCount: PROFILE_SAMPLE_COUNT,
+      firstRequestMedianMs: median(firstRequests.map((request) => request.elapsedMs)),
+      warmRequestMedianMs: median(warmRequests.map((request) => request.elapsedMs)),
+      firstRequest: aggregateRequests(firstRequests),
+      warmRequest: aggregateRequests(warmRequests),
+      samples: samples.map((sample) => ({
+        sample: sample.sample,
+        childProcessId: sample.report.processId,
+        nodeVersion: sample.report.nodeVersion,
+        compiledArtifactId: sample.report.artifact.compiledArtifactId,
+        artifactLoad: sample.report.artifactLoad,
+        firstRequest: sample.report.firstRequest,
+        warmRequest: sample.report.warmRequest,
+      })),
+    },
+    artifactLoad: {
+      sampleCount: samples.length,
+      medianElapsedMs: median(samples.map((sample) => sample.report.artifactLoad.elapsedMs)),
+      medianHeapDeltaBytes: median(samples.map((sample) => sample.report.artifactLoad.heapDeltaBytes)),
+    },
+    stages: {
+      firstRequest: aggregateStages(samples, "first"),
+      warmRequest: aggregateStages(samples, "warm"),
+    },
+    response: {
+      status: representative.report.warmRequest.status,
+      reason: representative.report.warmRequest.reason,
+      stationAreaCount: representative.report.warmRequest.stationAreaCatalogEntryCount,
+      serializedByteLength: representative.report.warmRequest.serializedByteLength,
+    },
+    validation: {
+      success: allRequests.every((request) => request.validationSuccess),
+      requests: allRequests.map((request) => ({
+        sample: request.sample,
+        requestKind: request.requestKind,
+        success: request.validationSuccess,
+        issues: request.validationIssues,
+      })),
+    },
+    diagnostics: collection.diagnosticSample === null ? null : {
+      sample: collection.diagnosticSample.sample,
+      childProcessId: collection.diagnosticSample.report.processId,
+      nodeVersion: collection.diagnosticSample.report.nodeVersion,
+      compiledArtifactId: collection.diagnosticSample.report.artifact.compiledArtifactId,
+      cpuProfilePath: collection.diagnosticSample.report.cpuProfilePath,
+      heapSnapshotPath: collection.diagnosticSample.report.heapSnapshotPath,
+      firstRequest: collection.diagnosticSample.report.firstRequest,
+      warmRequest: collection.diagnosticSample.report.warmRequest,
+    },
+  };
+  return report;
+}
+
+export function canonicalizeAccessProviderDescriptor(descriptor: ProviderDescriptor): ProviderDescriptor {
+  return {
+    ...descriptor,
+    provenance: {
+      ...descriptor.provenance,
+      retrievedAt: "<per-child-process>",
+    },
+  };
+}
+
+function validateSampleReport(report: ChildProfileReport, request: ChildRunRequest): void {
+  if (report.diagnostic !== request.diagnostic ||
+    report.firstRequest.sample !== request.sample || report.firstRequest.requestKind !== "first" ||
+    report.warmRequest.sample !== request.sample || report.warmRequest.requestKind !== "warm") {
+    throw new Error(`Profiling child ${request.sample} did not produce the requested first/warm pair.`);
+  }
+  if (request.cpuProfile !== (report.cpuProfilePath !== null) ||
+    request.heapSnapshots !== (report.heapSnapshotPath !== null)) {
+    throw new Error(`Profiling child ${request.sample} diagnostic routing does not match its report.`);
+  }
+  if (!report.firstRequest.validationSuccess || !report.warmRequest.validationSuccess ||
+    report.firstRequest.status !== "ok" || report.warmRequest.status !== "ok") {
+    throw new Error(`Profiling child ${request.sample} did not produce successful strictly validated requests.`);
+  }
+}
+
+function validateStableEvidence(samples: readonly ProfileSample[]): void {
+  const first = samples[0];
+  if (first === undefined) throw new Error("No profiling samples were produced.");
+  const artifactId = first.report.artifact.compiledArtifactId;
+  const artifactPath = first.report.artifact.path;
+  const requestIdentity = stableSerialize(first.report.request);
+  const providerIdentity = stableSerialize(canonicalizeAccessProviderDescriptor(first.report.accessProvider));
+  const processIds = new Set<number>();
+  for (const sample of samples) {
+    processIds.add(sample.report.processId);
+    if (sample.report.artifact.compiledArtifactId !== artifactId || sample.report.artifact.path !== artifactPath ||
+      stableSerialize(sample.report.request) !== requestIdentity ||
+      stableSerialize(canonicalizeAccessProviderDescriptor(sample.report.accessProvider)) !== providerIdentity) {
+      throw new Error(`Profiling child ${sample.sample} disagrees on artifact, request, or access-provider provenance.`);
+    }
+  }
+  if (processIds.size !== samples.length) throw new Error("Profiling samples did not run in distinct child processes.");
+}
+
+function isCanonicalRequest(value: unknown): value is ScheduledMeetingRequest {
+  if (!isRecord(value) || value.contractVersion !== "meeet-meeting/v3" || !Array.isArray(value.participants) || value.participants.length !== 2 ||
+    !isTolerance(value.tolerancePercent) || !isChangePreset(value.changeTimePreset) || typeof value.searchStartAt !== "string" || value.searchStartAt === "") return false;
+  return value.participants.every((participant) => isRecord(participant) && typeof participant.id === "string" && participant.id !== "" && participant.mode === "transit" &&
+    isRecord(participant.origin) && typeof participant.origin.label === "string" && Number.isFinite(participant.origin.latitude) && Number.isFinite(participant.origin.longitude));
+}
+
+function isAccessProviderDescriptor(value: unknown): value is ProviderDescriptor {
+  if (!isRecord(value) || typeof value.name !== "string" || !isDeployment(value.deployment) || !isDataKind(value.dataKind) || typeof value.liveData !== "boolean" ||
+    typeof value.asOf !== "string" || typeof value.notes !== "string" || !isRecord(value.provenance)) return false;
+  const provenance = value.provenance;
+  return provenance.role === "access" && typeof provenance.provider === "string" && isDeployment(provenance.deployment) && isDataKind(provenance.dataKind) &&
+    provenance.liveData === false && (provenance.sourceUrl === null || typeof provenance.sourceUrl === "string") &&
+    (provenance.license === null || (isRecord(provenance.license) && typeof provenance.license.name === "string" && typeof provenance.license.url === "string")) &&
+    typeof provenance.attribution === "string" && typeof provenance.version === "string" && typeof provenance.retrievedAt === "string" &&
+    typeof provenance.notes === "string" && provenance.feeds === null && value.liveData === false && value.dataKind === provenance.dataKind &&
+    value.deployment === provenance.deployment && value.asOf === provenance.version && value.notes === provenance.notes;
+}
+
+function isArtifact(value: unknown): value is ChildProfileReport["artifact"] {
+  return isRecord(value) && typeof value.path === "string" && value.path !== "" && typeof value.compiledArtifactId === "string" && value.compiledArtifactId !== "" &&
+    typeof value.feedId === "string" && value.feedId !== "" && isRecord(value.serviceDateRange) && typeof value.serviceDateRange.firstDate === "string" &&
+    typeof value.serviceDateRange.lastDate === "string" && isSafeCount(value.stationAreaCount) && isSafeCount(value.connectionCount);
+}
+
+function isArtifactLoad(value: unknown): value is ChildProfileReport["artifactLoad"] {
+  return isRecord(value) && isNonNegativeFinite(value.elapsedMs) && Number.isFinite(value.heapDeltaBytes);
+}
+
+function isRequestMeasurement(value: unknown): value is RequestMeasurement {
+  return isRecord(value) && isPositiveSafeInteger(value.sample) && (value.requestKind === "first" || value.requestKind === "warm") &&
+    isNonNegativeFinite(value.elapsedMs) && isNonNegativeFinite(value.calculationElapsedMs) && isNonNegativeFinite(value.validationElapsedMs) &&
+    isNonNegativeFinite(value.serializationElapsedMs) && Number.isFinite(value.heapDeltaBytes) && (value.status === "ok" || value.status === "no-result") &&
+    (value.reason === null || value.reason === "no-access-seeds" || value.reason === "no-reachable-stations") && typeof value.validationSuccess === "boolean" &&
+    (value.validationIssues === null || Array.isArray(value.validationIssues)) && isSafeCount(value.serializedByteLength) && isSafeCount(value.stationAreaCatalogEntryCount);
+}
+
+function isStageList(value: unknown): value is readonly StageMeasurement[] {
+  if (!Array.isArray(value) || value.length !== EXPECTED_CALCULATION_STAGES.length * 2) return false;
+  const seen = new Set<string>();
+  for (const stage of value) {
+    if (!isRecord(stage) || typeof stage.stage !== "string" || !EXPECTED_CALCULATION_STAGES.includes(stage.stage as typeof EXPECTED_CALCULATION_STAGES[number]) ||
+      (stage.requestKind !== "first" && stage.requestKind !== "warm") || !isNonNegativeFinite(stage.elapsedMs) || !Number.isFinite(stage.heapDeltaBytes)) return false;
+    const key = `${stage.requestKind}:${stage.stage}`;
+    if (seen.has(key)) return false;
+    seen.add(key);
+  }
+  return seen.size === EXPECTED_CALCULATION_STAGES.length * 2;
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
+}
+
+function isNullableString(value: unknown): value is string | null {
+  return value === null || typeof value === "string";
+}
+
+function isPositiveSafeInteger(value: unknown): value is number {
+  return typeof value === "number" && Number.isSafeInteger(value) && value > 0;
+}
+
+function isSafeCount(value: unknown): value is number {
+  return typeof value === "number" && Number.isSafeInteger(value) && value >= 0;
+}
+
+function isNonNegativeFinite(value: unknown): value is number {
+  return typeof value === "number" && Number.isFinite(value) && value >= 0;
+}
+
+function isTolerance(value: unknown): value is 5 | 10 | 15 {
+  return value === 5 || value === 10 || value === 15;
+}
+
+function isChangePreset(value: unknown): value is "quick" | "medium" | "long" {
+  return value === "quick" || value === "medium" || value === "long";
+}
+
+function isDeployment(value: unknown): boolean {
+  return value === "fixture" || value === "self-hosted" || value === "managed" || value === "unknown";
+}
+
+function isDataKind(value: unknown): boolean {
+  return value === "demo-static" || value === "scheduled" || value === "access" || value === "live" || value === "unknown";
+}
+
+function aggregateRequests(requests: readonly RequestMeasurement[]): RequestAggregate {
+  return {
+    sampleCount: requests.length,
+    medianElapsedMs: median(requests.map((request) => request.elapsedMs)),
+    medianCalculationElapsedMs: median(requests.map((request) => request.calculationElapsedMs)),
+    medianValidationElapsedMs: median(requests.map((request) => request.validationElapsedMs)),
+    medianSerializationElapsedMs: median(requests.map((request) => request.serializationElapsedMs)),
+    medianHeapDeltaBytes: median(requests.map((request) => request.heapDeltaBytes)),
+  };
+}
+
+function aggregateStages(samples: readonly ProfileSample[], requestKind: RequestKind): readonly StageAggregate[] {
+  return EXPECTED_CALCULATION_STAGES.map((stage) => {
+    const values = samples.flatMap((sample) => sample.report.stages.filter((candidate) => candidate.stage === stage && candidate.requestKind === requestKind));
+    return { stage, sampleCount: values.length, medianElapsedMs: median(values.map((value) => value.elapsedMs)), medianHeapDeltaBytes: median(values.map((value) => value.heapDeltaBytes)) };
+  });
+}
+
+function median(values: readonly number[]): number {
+  if (values.length === 0) throw new Error("Cannot calculate a median without samples.");
+  const sorted = [...values].sort((left, right) => left - right);
+  const middle = Math.floor(sorted.length / 2);
+  const lower = sorted[middle - 1];
+  const upper = sorted[middle];
+  if (lower === undefined || upper === undefined) throw new Error("Median sample indexing failed.");
+  return sorted.length % 2 === 0 ? (lower + upper) / 2 : upper;
+}
+
+function stableSerialize(value: unknown): string {
+  if (value === null || typeof value !== "object") return JSON.stringify(value);
+  if (Array.isArray(value)) return `[${value.map((entry) => stableSerialize(entry)).join(",")}]`;
+  const record = value as Record<string, unknown>;
+  return `{${Object.keys(record).sort().map((key) => `${JSON.stringify(key)}:${stableSerialize(record[key])}`).join(",")}}`;
+}

--- a/scripts/profile-scheduled-calculation-worker.ts
+++ b/scripts/profile-scheduled-calculation-worker.ts
@@ -1,0 +1,293 @@
+// One fresh-process sample for profile-scheduled-calculation.ts. This file is
+// intentionally a separate entry point: the parent must be able to prove that
+// every first request starts in a new Node 24 process, rather than merely
+// clearing in-process caches.
+
+import { writeFileSync } from "node:fs";
+import { Session } from "node:inspector";
+import { resolve as resolvePath } from "node:path";
+import { fileURLToPath } from "node:url";
+import { writeHeapSnapshot } from "node:v8";
+
+import { loadScheduledArtifact } from "../lib/domain/scheduled-routing/artifact.ts";
+import {
+  calculateScheduledMeetingWithBasis,
+  type ScheduledCalculationStage,
+} from "../lib/domain/scheduled-routing/meeting.ts";
+import { clearScheduledRoutingWindowCache } from "../lib/domain/scheduled-routing/router.ts";
+import { clearScheduledStationAreaCatalogCache } from "../lib/domain/scheduled-routing/surface.ts";
+import { elapsedMs } from "../lib/log.ts";
+import { MvgScheduledAccessSeedProvider } from "../lib/providers/mvg-scheduled-access.ts";
+import {
+  parseScheduledMeetingRequest,
+  validateScheduledMeetingResponse,
+  type ScheduledMeetingRequest,
+} from "../lib/validation/meeting-v3.ts";
+
+const ARTIFACT_PATH = resolvePath("data/scheduled/mvv-scheduled-artifact.json");
+const PROFILES_DIR = resolvePath("profiles");
+const SEARCH_START_AT = "2026-08-11T08:05:00+02:00";
+
+const REQUEST = {
+  contractVersion: "meeet-meeting/v3",
+  participants: [
+    { id: "red", origin: { label: "Red", latitude: 48.1374, longitude: 11.5755 }, mode: "transit" },
+    { id: "blue", origin: { label: "Blue", latitude: 48.14, longitude: 11.57 }, mode: "transit" },
+  ],
+  tolerancePercent: 10,
+  changeTimePreset: "medium",
+  searchStartAt: SEARCH_START_AT,
+};
+
+type RequestKind = "first" | "warm";
+
+interface StageMeasurement {
+  readonly stage: string;
+  readonly requestKind: RequestKind;
+  readonly elapsedMs: number;
+  readonly heapDeltaBytes: number;
+}
+
+interface StageSpan {
+  readonly stage: ScheduledCalculationStage;
+  readonly startedAt: number;
+  readonly heapBefore: number;
+}
+
+interface RequestMeasurement {
+  readonly sample: number;
+  readonly requestKind: RequestKind;
+  readonly elapsedMs: number;
+  readonly calculationElapsedMs: number;
+  readonly validationElapsedMs: number;
+  readonly serializationElapsedMs: number;
+  readonly heapDeltaBytes: number;
+  readonly status: "ok" | "no-result";
+  readonly reason: "no-access-seeds" | "no-reachable-stations" | null;
+  readonly validationSuccess: boolean;
+  readonly validationIssues: readonly unknown[] | null;
+  readonly serializedByteLength: number;
+  readonly stationAreaCatalogEntryCount: number;
+}
+
+interface CpuProfilerSession {
+  readonly session: Session;
+}
+
+function main(): void {
+  const nodeMajor = Number(process.versions.node.split(".")[0]);
+  if (nodeMajor !== 24) {
+    console.error(`[profile-worker] the scheduled artifact requires Node 24 (current major: ${nodeMajor}).`);
+    process.exitCode = 2;
+    return;
+  }
+  try {
+    const sample = parseIntegerArgument("--sample");
+    const outputPath = parseStringArgument("--output");
+    const diagnostic = process.argv.includes("--diagnostic");
+    const heapSnapshots = process.argv.includes("--heap-snapshots");
+    const cpuProfile = process.argv.includes("--inspector-cpu");
+    void run(sample, outputPath, diagnostic, heapSnapshots, cpuProfile).catch((error: unknown) => {
+      console.error(`[profile-worker] failed: ${error instanceof Error ? (error.stack ?? error.message) : String(error)}`);
+      process.exitCode = 1;
+    });
+  } catch (error: unknown) {
+    console.error(`[profile-worker] failed: ${error instanceof Error ? (error.stack ?? error.message) : String(error)}`);
+    process.exitCode = 1;
+  }
+}
+
+async function run(sample: number, outputPath: string, diagnostic: boolean, heapSnapshots: boolean, cpuProfile: boolean): Promise<void> {
+  const parsed = parseScheduledMeetingRequest(REQUEST);
+  if (!parsed.success) throw new Error(`The fixed profile request failed validation: ${JSON.stringify(parsed.issues)}`);
+
+  const artifactLoadHeapBefore = process.memoryUsage().heapUsed;
+  const artifactLoadStartedAt = performance.now();
+  const artifact = loadScheduledArtifact(ARTIFACT_PATH);
+  const artifactLoadElapsedMs = elapsedMs(artifactLoadStartedAt);
+  const artifactLoadHeapDeltaBytes = process.memoryUsage().heapUsed - artifactLoadHeapBefore;
+
+  // This child is fresh already; these explicit resets document and enforce
+  // that the first request starts on the cold catalog/window path.
+  clearScheduledStationAreaCatalogCache();
+  clearScheduledRoutingWindowCache();
+  const access = new MvgScheduledAccessSeedProvider();
+  const stageMeasurements: StageMeasurement[] = [];
+  const profiler = cpuProfile ? await startCpuProfiler() : null;
+  const firstRequest = await runRequest(parsed.data, artifact, access, sample, "first", stageMeasurements);
+  const warmRequest = await runRequest(parsed.data, artifact, access, sample, "warm", stageMeasurements);
+  const cpuProfilePath = profiler === null ? null : await stopCpuProfiler(profiler);
+
+  // Snapshot I/O happens only after both request timers have ended and after
+  // the CPU profile has stopped. It cannot perturb the warm measurement.
+  const heapSnapshotPath = heapSnapshots
+    ? resolvePath(PROFILES_DIR, `heap-profile-sample-${sample}-${new Date().toISOString().replaceAll(":", "-")}.heapsnapshot`)
+    : null;
+  if (heapSnapshotPath !== null) writeHeapSnapshot(heapSnapshotPath);
+
+  const report = {
+    contractVersion: "meeet-calculation-profile-child/v2" as const,
+    nodeVersion: process.versions.node,
+    processId: process.pid,
+    diagnostic,
+    request: parsed.data,
+    accessProvider: access.descriptor,
+    artifact: {
+      path: ARTIFACT_PATH,
+      compiledArtifactId: artifact.provenance.compiledArtifactId,
+      feedId: artifact.feedId,
+      serviceDateRange: artifact.serviceDateRange,
+      stationAreaCount: artifact.stationAreas.length,
+      connectionCount: artifact.connections.length,
+    },
+    artifactLoad: {
+      elapsedMs: artifactLoadElapsedMs,
+      heapDeltaBytes: artifactLoadHeapDeltaBytes,
+    },
+    firstRequest,
+    warmRequest,
+    stages: stageMeasurements,
+    cpuProfilePath,
+    heapSnapshotPath,
+  };
+  writeFileSync(outputPath, `${JSON.stringify(report, null, 2)}\n`);
+
+  const requests = [firstRequest, warmRequest];
+  const failedValidation = requests.find((request) => !request.validationSuccess);
+  if (failedValidation !== undefined) {
+    console.error(`[profile-worker] ${failedValidation.requestKind} request failed strict validation: ${JSON.stringify(failedValidation.validationIssues)}`);
+    process.exitCode = 1;
+    return;
+  }
+  const failedStatus = requests.find((request) => request.status !== "ok");
+  if (failedStatus !== undefined) {
+    console.error(`[profile-worker] ${failedStatus.requestKind} request returned status ${failedStatus.status} (reason=${failedStatus.reason}).`);
+    process.exitCode = 1;
+  }
+}
+
+async function runRequest(
+  request: ScheduledMeetingRequest,
+  artifact: NonNullable<Parameters<typeof calculateScheduledMeetingWithBasis>[1]["artifact"]>,
+  access: MvgScheduledAccessSeedProvider,
+  sample: number,
+  requestKind: RequestKind,
+  stageMeasurements: StageMeasurement[],
+): Promise<RequestMeasurement> {
+  const requestHeapBefore = process.memoryUsage().heapUsed;
+  const stageSpans: StageSpan[] = [];
+  const recordStage = (stage: string, startedAt: number, heapBefore: number, endedAt: number, heapAfter: number): void => {
+    stageMeasurements.push({
+      stage,
+      requestKind,
+      elapsedMs: Math.trunc(endedAt - startedAt),
+      heapDeltaBytes: heapAfter - heapBefore,
+    });
+  };
+  const finishLastStage = (endedAt: number, heapAfter: number): void => {
+    const lastSpan = stageSpans[stageSpans.length - 1];
+    if (lastSpan !== undefined) recordStage(lastSpan.stage, lastSpan.startedAt, lastSpan.heapBefore, endedAt, heapAfter);
+  };
+  const hooks = {
+    async onStage(stage: ScheduledCalculationStage): Promise<void> {
+      const now = performance.now();
+      const heapNow = process.memoryUsage().heapUsed;
+      const previous = stageSpans[stageSpans.length - 1];
+      if (previous !== undefined) finishLastStage(now, heapNow);
+      stageSpans.push({ stage, startedAt: now, heapBefore: heapNow });
+    },
+  };
+
+  // No snapshot I/O occurs after this timer starts. Stage hooks only collect
+  // scalar timestamps/heap and do not perform disk work.
+  const requestStartedAt = performance.now();
+  const calculationStartedAt = performance.now();
+  const calculation = await calculateScheduledMeetingWithBasis(request, { artifact, access }, undefined, hooks);
+  const calculationElapsedMs = elapsedMs(calculationStartedAt);
+  finishLastStage(performance.now(), process.memoryUsage().heapUsed);
+
+  const validationStartedAt = performance.now();
+  const validation = validateScheduledMeetingResponse(calculation.response, request, {
+    stationAreaCatalog: calculation.stationAreaCatalog,
+  });
+  const validationElapsedMs = elapsedMs(validationStartedAt);
+
+  const serializationStartedAt = performance.now();
+  const serialized = JSON.stringify(calculation.response);
+  const serializationElapsedMs = elapsedMs(serializationStartedAt);
+  const requestElapsedMs = elapsedMs(requestStartedAt);
+  const serializedByteLength = new TextEncoder().encode(serialized).byteLength;
+
+  return {
+    sample,
+    requestKind,
+    elapsedMs: requestElapsedMs,
+    calculationElapsedMs,
+    validationElapsedMs,
+    serializationElapsedMs,
+    heapDeltaBytes: process.memoryUsage().heapUsed - requestHeapBefore,
+    status: calculation.response.status,
+    reason: calculation.response.reason,
+    validationSuccess: validation.success,
+    validationIssues: validation.success ? null : validation.issues,
+    serializedByteLength,
+    stationAreaCatalogEntryCount: calculation.stationAreaCatalog.entries.length,
+  };
+}
+
+function parseIntegerArgument(name: string): number {
+  const value = parseStringArgument(name);
+  const parsed = Number(value);
+  if (!Number.isSafeInteger(parsed) || parsed < 1) throw new Error(`${name} must be a positive integer.`);
+  return parsed;
+}
+
+function parseStringArgument(name: string): string {
+  const index = process.argv.indexOf(name);
+  const value = index < 0 ? undefined : process.argv[index + 1];
+  if (value === undefined || value.trim() === "") throw new Error(`${name} is required.`);
+  return value;
+}
+
+function startCpuProfiler(): Promise<CpuProfilerSession> {
+  const session = new Session();
+  session.connect();
+  return new Promise((resolve, reject) => {
+    session.post("Profiler.enable", (enableError) => {
+      if (enableError !== null) {
+        reject(enableError);
+        return;
+      }
+      session.post("Profiler.start", (startError) => {
+        if (startError !== null) {
+          reject(startError);
+          return;
+        }
+        resolve({ session });
+      });
+    });
+  });
+}
+
+function stopCpuProfiler(profiler: CpuProfilerSession): Promise<string> {
+  return new Promise((resolve, reject) => {
+    profiler.session.post("Profiler.stop", (stopError, profile) => {
+      profiler.session.disconnect();
+      if (stopError !== null) {
+        reject(stopError);
+        return;
+      }
+      const profilePath = resolvePath(PROFILES_DIR, `cpu-calculation-sample-${new Date().toISOString().replaceAll(":", "-")}.cpuprofile`);
+      writeFileSync(profilePath, `${JSON.stringify(profile)}\n`);
+      console.error(`[profile-worker] cpu profile written to ${profilePath}`);
+      resolve(profilePath);
+    });
+  });
+}
+
+function isDirectExecution(): boolean {
+  const entrypoint = process.argv[1];
+  return entrypoint !== undefined && resolvePath(entrypoint) === resolvePath(fileURLToPath(import.meta.url));
+}
+
+if (isDirectExecution()) void main();

--- a/scripts/profile-scheduled-calculation.ts
+++ b/scripts/profile-scheduled-calculation.ts
@@ -1,81 +1,33 @@
-// Profiling harness for a full scheduled meeting calculation on the real MVV
-// feed (issue #72). Reports stage-by-stage elapsed times and heap deltas for
-// one cold calculation: artifact load, access seeds, station-area catalog,
-// routing-window materialization, both participant scans, participant
-// surfaces, station-area evaluation, response build, validation, and
-// serialization.
+// Parent harness for v2 fresh-process paired scheduled-calculation profiling
+// (issue #72, issue #90). Exactly three uninstrumented Node 24 children supply
+// the first/warm timing medians. If CPU or heap diagnostics are requested, a
+// separate fourth child runs one diagnostic pair and is excluded from every
+// timing, stage, and heap aggregate.
 //
-// Requirements:
-// - Node major 24 (the scheduled artifact is written and loaded by Node 24).
-// - The real artifact at data/scheduled/mvv-scheduled-artifact.json (see
-//   `npm run schedule:compile:mvv`).
-// - Live MVG nearby access (the real calculation resolves access seeds over
-//   the network).
-//
-// Usage:
-//   npm run profile:calculation
-//   npm run profile:calculation:cpu        # also writes profiles/cpu-calculation-*.cpuprofile
-//   npm run profile:calculation -- --heap-snapshots   # also writes per-stage heap snapshots
-//
-// The CPU profile covers exactly the measured window (artifact load through
-// serialization) via node:inspector, so tsx/loader startup is not included.
-//
-// Output contract: the JSON report is written to
-// profiles/report-<compiledArtifactId>-<timestamp>.json and its path is
-// printed to stdout; human-readable progress goes to stderr. Exit codes:
-// 0 = success, 1 = calculation or validation failure, 2 = unsupported Node
-// major.
+// Child stdout is never parsed: the worker writes a JSON report to a temporary
+// path and the parent reads that file. Request timers begin after child startup,
+// request parsing, and artifact load, and end after calculation, strict
+// validation with calculation.stationAreaCatalog, and response serialization.
 
-import { mkdirSync, writeFileSync } from "node:fs";
-import { Session } from "node:inspector";
+import { existsSync, mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs";
+import { spawnSync } from "node:child_process";
+import { createRequire } from "node:module";
+import { fileURLToPath } from "node:url";
 import { resolve as resolvePath } from "node:path";
-import { writeHeapSnapshot } from "node:v8";
 
-import { loadScheduledArtifact } from "../lib/domain/scheduled-routing/artifact.ts";
 import {
-  calculateScheduledMeetingWithBasis,
-  type ScheduledCalculationStage,
-} from "../lib/domain/scheduled-routing/meeting.ts";
-import { clearScheduledRoutingWindowCache } from "../lib/domain/scheduled-routing/router.ts";
-import { buildScheduledStationAreaCatalog } from "../lib/domain/scheduled-routing/surface.ts";
-import { elapsedMs } from "../lib/log.ts";
-import { MvgScheduledAccessSeedProvider } from "../lib/providers/mvg-scheduled-access.ts";
-import {
-  parseScheduledMeetingRequest,
-  validateScheduledMeetingResponse,
-  type ScheduledMeetingRequest,
-} from "../lib/validation/meeting-v3.ts";
+  aggregateProfile,
+  buildWorkerLaunch,
+  collectProfileSamples,
+  PROFILE_SAMPLE_COUNT,
+  type AggregateProfileReport,
+  type ChildProfileReport,
+  type ChildRunRequest,
+} from "./profile-scheduled-calculation-protocol.ts";
 
-const ARTIFACT_PATH = resolvePath("data/scheduled/mvv-scheduled-artifact.json");
 const PROFILES_DIR = resolvePath("profiles");
-
-// Fixed, reproducible request inside the artifact's routable coverage bounds
-// (2026-08-01T04:08:01Z .. 2026-10-30T22:59:59Z). A weekday morning keeps the
-// measured service day representative of full service.
-const SEARCH_START_AT = "2026-08-11T08:05:00+02:00";
-
-const REQUEST = {
-  contractVersion: "meeet-meeting/v3",
-  participants: [
-    { id: "red", origin: { label: "Red", latitude: 48.1374, longitude: 11.5755 }, mode: "transit" },
-    { id: "blue", origin: { label: "Blue", latitude: 48.14, longitude: 11.57 }, mode: "transit" },
-  ],
-  tolerancePercent: 10,
-  changeTimePreset: "medium",
-  searchStartAt: SEARCH_START_AT,
-};
-
-interface StageMeasurement {
-  readonly stage: string;
-  readonly elapsedMs: number;
-  readonly heapDeltaBytes: number;
-}
-
-interface StageSpan {
-  readonly stage: ScheduledCalculationStage;
-  readonly startedAt: number;
-  readonly heapBefore: number;
-}
+const WORKER_PATH = resolvePath("scripts/profile-scheduled-calculation-worker.ts");
+const TSX_CLI_PATH = createRequire(import.meta.url).resolve("tsx/cli");
 
 function main(): void {
   const nodeMajor = Number(process.versions.node.split(".")[0]);
@@ -87,186 +39,71 @@ function main(): void {
   const heapSnapshots = process.argv.includes("--heap-snapshots");
   const cpuProfile = process.argv.includes("--inspector-cpu");
   mkdirSync(PROFILES_DIR, { recursive: true });
-
-  const parsed = parseScheduledMeetingRequest(REQUEST);
-  if (!parsed.success) {
-    console.error(`[profile] the fixed profile request failed validation: ${JSON.stringify(parsed.issues)}`);
-    process.exitCode = 1;
-    return;
-  }
-
-  void run(parsed.data, heapSnapshots, cpuProfile).catch((error: unknown) => {
+  try {
+    run(heapSnapshots, cpuProfile);
+  } catch (error: unknown) {
     console.error(`[profile] harness failed: ${error instanceof Error ? (error.stack ?? error.message) : String(error)}`);
     process.exitCode = 1;
-  });
+  }
 }
 
-async function run(
-  request: ScheduledMeetingRequest,
-  heapSnapshots: boolean,
-  cpuProfile: boolean,
-): Promise<void> {
-  const measurements: StageMeasurement[] = [];
-  const recordStage = (stage: string, elapsedMsValue: number, heapDeltaBytes: number): void => {
-    measurements.push({ stage, elapsedMs: elapsedMsValue, heapDeltaBytes });
-  };
-
-  const profiler = cpuProfile ? await startCpuProfiler() : null;
-  const artifactLoadHeapBefore = process.memoryUsage().heapUsed;
-  const artifactLoadStartedAt = performance.now();
-  const artifact = loadScheduledArtifact(ARTIFACT_PATH);
-  const artifactLoadHeapDelta = process.memoryUsage().heapUsed - artifactLoadHeapBefore;
-  recordStage("artifact-load", elapsedMs(artifactLoadStartedAt), artifactLoadHeapDelta);
-  if (heapSnapshots) {
-    const snapshotStartedAt = performance.now();
-    writeHeapSnapshot(resolvePath(PROFILES_DIR, "heap-artifact-load.heapsnapshot"));
-    recordStage("heap-snapshot:artifact-load", elapsedMs(snapshotStartedAt), 0);
-  }
-
-  // One cold calculation per process: drop any routing-window cache entries so
-  // the measured window materialization is the real cold path.
-  clearScheduledRoutingWindowCache();
-
-  const access = new MvgScheduledAccessSeedProvider();
-  const stageSpans: StageSpan[] = [];
-  const hooks = {
-    async onStage(stage: ScheduledCalculationStage): Promise<void> {
-      const now = performance.now();
-      const heapNow = process.memoryUsage().heapUsed;
-      if (stageSpans.length > 0) {
-        const previous = stageSpans[stageSpans.length - 1];
-        recordStage(previous.stage, Math.trunc(now - previous.startedAt), heapNow - previous.heapBefore);
-        if (heapSnapshots) {
-          const snapshotStartedAt = performance.now();
-          writeHeapSnapshot(resolvePath(PROFILES_DIR, `heap-${previous.stage}.heapsnapshot`));
-          recordStage(`heap-snapshot:${previous.stage}`, elapsedMs(snapshotStartedAt), 0);
-        }
-      }
-      stageSpans.push({ stage, startedAt: now, heapBefore: heapNow });
-    },
-  };
-
-  const calculation = await calculateScheduledMeetingWithBasis(request, { artifact, access }, undefined, hooks);
-  const calculationEndedAt = performance.now();
-  const heapAfterCalculation = process.memoryUsage().heapUsed;
-  if (stageSpans.length > 0) {
-    const lastSpan = stageSpans[stageSpans.length - 1];
-    recordStage(lastSpan.stage, Math.trunc(calculationEndedAt - lastSpan.startedAt), heapAfterCalculation - lastSpan.heapBefore);
-    if (heapSnapshots) {
-      const snapshotStartedAt = performance.now();
-      writeHeapSnapshot(resolvePath(PROFILES_DIR, `heap-${lastSpan.stage}.heapsnapshot`));
-      recordStage(`heap-snapshot:${lastSpan.stage}`, elapsedMs(snapshotStartedAt), 0);
-    }
-  }
-
-  const validationStartedAt = performance.now();
-  const stationAreaCatalog = buildScheduledStationAreaCatalog(artifact);
-  const validation = validateScheduledMeetingResponse(calculation.response, request, { stationAreaCatalog });
-  recordStage("validation", elapsedMs(validationStartedAt), 0);
-
-  const serializationStartedAt = performance.now();
-  const serialized = JSON.stringify(calculation.response);
-  recordStage("serialization", elapsedMs(serializationStartedAt), 0);
-
-  const totalElapsedMs = elapsedMs(artifactLoadStartedAt);
-  const cpuProfilePath = profiler === null ? null : await stopCpuProfiler(profiler, serialized);
-  const report = {
-    contractVersion: "meeet-calculation-profile/v1",
-    nodeVersion: process.versions.node,
-    artifact: {
-      path: ARTIFACT_PATH,
-      compiledArtifactId: artifact.provenance.compiledArtifactId,
-      feedId: artifact.feedId,
-      serviceDateRange: artifact.serviceDateRange,
-      stationAreaCount: artifact.stationAreas.length,
-      connectionCount: artifact.connections.length,
-    },
-    request: {
-      searchStartAt: request.searchStartAt,
-      tolerancePercent: request.tolerancePercent,
-      changeTimePreset: request.changeTimePreset,
-      participants: request.participants.map((participant) => ({
-        id: participant.id,
-        origin: participant.origin,
-      })),
-    },
-    accessProvider: access.descriptor,
-    stages: measurements,
-    totalElapsedMs,
-    response: {
-      status: calculation.response.status,
-      reason: calculation.response.reason,
-      stationAreaCount: calculation.response.stationAreas.length,
-      serializedByteLength: new TextEncoder().encode(serialized).byteLength,
-    },
-    validation: { success: validation.success },
-    cpuProfilePath,
-  };
-
-  const reportPath = resolvePath(PROFILES_DIR, `report-${artifact.provenance.compiledArtifactId.slice(0, 12)}-${new Date().toISOString().replaceAll(":", "-")}.json`);
+function run(heapSnapshots: boolean, cpuProfile: boolean): void {
+  if (!existsSync(WORKER_PATH) || !existsSync(TSX_CLI_PATH)) throw new Error("The repository tsx runner or profiling worker is missing.");
+  const collection = collectProfileSamples({
+    cpuProfile,
+    heapSnapshots,
+    runChild: (request) => runChild(request),
+  });
+  const report = aggregateProfile(collection);
+  const reportPath = resolvePath(PROFILES_DIR, `report-${report.artifact.compiledArtifactId.slice(0, 12)}-${new Date().toISOString().replaceAll(":", "-")}.json`);
   writeFileSync(reportPath, `${JSON.stringify(report, null, 2)}\n`);
   process.stdout.write(`${reportPath}\n`);
-  printRankedTable(measurements, totalElapsedMs);
-
-  if (!validation.success) {
-    console.error(`[profile] the calculated response failed strict validation: ${JSON.stringify(validation.issues)}`);
-    process.exitCode = 1;
-    return;
-  }
-  if (calculation.response.status !== "ok") {
-    console.error(`[profile] the calculation returned status ${calculation.response.status} (reason=${calculation.response.reason}); the profile request must be a successful calculation.`);
-    process.exitCode = 1;
-  }
+  printRankedTable(report);
 }
 
-interface CpuProfilerSession {
-  readonly session: Session;
-}
-
-function startCpuProfiler(): Promise<CpuProfilerSession> {
-  const session = new Session();
-  session.connect();
-  return new Promise((resolve, reject) => {
-    session.post("Profiler.enable", (enableError) => {
-      if (enableError !== null) {
-        reject(enableError);
-        return;
-      }
-      session.post("Profiler.start", (startError) => {
-        if (startError !== null) {
-          reject(startError);
-          return;
-        }
-        resolve({ session });
-      });
+function runChild(request: ChildRunRequest): ChildProfileReport {
+  const temporaryDirectory = mkdtempSync(resolvePath(PROFILES_DIR, ".calculation-profile-sample-"));
+  const outputPath = resolvePath(temporaryDirectory, "sample.json");
+  try {
+    const launch = buildWorkerLaunch({
+      nodePath: process.execPath,
+      tsxCliPath: TSX_CLI_PATH,
+      workerPath: WORKER_PATH,
+      outputPath,
+      request,
     });
-  });
-}
-
-function stopCpuProfiler(profiler: CpuProfilerSession, serialized: string): Promise<string> {
-  return new Promise((resolve, reject) => {
-    profiler.session.post("Profiler.stop", (stopError, profile) => {
-      profiler.session.disconnect();
-      if (stopError !== null) {
-        reject(stopError);
-        return;
-      }
-      const profilePath = resolvePath(PROFILES_DIR, `cpu-calculation-${new Date().toISOString().replaceAll(":", "-")}.cpuprofile`);
-      writeFileSync(profilePath, `${JSON.stringify(profile)}\n`);
-      console.error(`[profile] cpu profile written to ${profilePath} (${serialized.length} bytes serialized response)`);
-      resolve(profilePath);
+    const result = spawnSync(launch.command, [...launch.args], {
+      cwd: process.cwd(),
+      env: { ...process.env, NODE_OPTIONS: `${process.env.NODE_OPTIONS ?? ""} --conditions=react-server`.trim() },
+      stdio: ["ignore", "ignore", "inherit"],
     });
-  });
-}
-
-function printRankedTable(measurements: readonly StageMeasurement[], totalElapsedMs: number): void {
-  const ranked = [...measurements].sort((left, right) => right.elapsedMs - left.elapsedMs);
-  console.error("[profile] stage timings (ranked by elapsed ms):");
-  for (const measurement of ranked) {
-    const share = totalElapsedMs === 0 ? 0 : (measurement.elapsedMs / totalElapsedMs) * 100;
-    console.error(`[profile]   ${measurement.stage.padEnd(28)} ${String(measurement.elapsedMs).padStart(8)} ms  ${share.toFixed(1).padStart(5)}%  heapDelta=${measurement.heapDeltaBytes} bytes`);
+    if (result.error !== undefined) throw new Error(`Fresh-process profile sample ${request.sample} could not start: ${result.error.message}`);
+    if (result.status !== 0) throw new Error(`Fresh-process profile sample ${request.sample} exited with status ${String(result.status)}${result.signal === null ? "" : ` (signal ${result.signal})`}.`);
+    return JSON.parse(readFileSync(outputPath, "utf8")) as ChildProfileReport;
+  } finally {
+    rmSync(temporaryDirectory, { recursive: true, force: true });
   }
-  console.error(`[profile] total: ${totalElapsedMs} ms`);
 }
 
-void main();
+function printRankedTable(report: AggregateProfileReport): void {
+  console.error(`[profile] schema=v2 compiledArtifactId=${report.artifact.compiledArtifactId} fresh-process timing samples=${PROFILE_SAMPLE_COUNT}`);
+  console.error(`[profile] request medians: first=${report.requestTimings.firstRequestMedianMs} ms, warm=${report.requestTimings.warmRequestMedianMs} ms`);
+  console.error(`[profile] artifact-load median=${report.artifactLoad.medianElapsedMs} ms heapDelta=${Math.trunc(report.artifactLoad.medianHeapDeltaBytes)} bytes`);
+  console.error("[profile] stage medians (first then warm):");
+  for (const requestKind of ["firstRequest", "warmRequest"] as const) {
+    const stages = [...report.stages[requestKind]].sort((left, right) => right.medianElapsedMs - left.medianElapsedMs);
+    for (const stage of stages) {
+      console.error(`[profile]   ${requestKind}:${stage.stage.padEnd(28)} ${String(stage.medianElapsedMs).padStart(8)} ms  heapDelta=${Math.trunc(stage.medianHeapDeltaBytes)} bytes`);
+    }
+  }
+  if (report.diagnostics !== null) {
+    console.error(`[profile] diagnostics: child=${report.diagnostics.childProcessId} cpu=${report.diagnostics.cpuProfilePath ?? "none"} heap=${report.diagnostics.heapSnapshotPath ?? "none"}`);
+  }
+}
+
+function isDirectExecution(): boolean {
+  const entrypoint = process.argv[1];
+  return entrypoint !== undefined && resolvePath(entrypoint) === resolvePath(fileURLToPath(import.meta.url));
+}
+
+if (isDirectExecution()) main();

--- a/test/scheduled-calculation-profile.test.ts
+++ b/test/scheduled-calculation-profile.test.ts
@@ -1,0 +1,188 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import {
+  aggregateProfile,
+  buildWorkerLaunch,
+  collectProfileSamples,
+  EXPECTED_CALCULATION_STAGES,
+  type ChildProfileReport,
+  type ChildRunRequest,
+  type StageMeasurement,
+} from "../scripts/profile-scheduled-calculation-protocol.ts";
+import {
+  FIXTURE_SCHEDULED_ACCESS_PROVIDER,
+  FIXTURE_SCHEDULED_ARTIFACT,
+} from "../lib/fixtures/scheduled-routing.ts";
+import { parseScheduledMeetingRequest, type ScheduledMeetingRequest } from "../lib/validation/meeting-v3.ts";
+
+const REQUEST = {
+  contractVersion: "meeet-meeting/v3",
+  participants: [
+    { id: "red", origin: { label: "Red", latitude: 48.1374, longitude: 11.5755 }, mode: "transit" },
+    { id: "blue", origin: { label: "Blue", latitude: 48.14, longitude: 11.57 }, mode: "transit" },
+  ],
+  tolerancePercent: 10,
+  changeTimePreset: "medium",
+  searchStartAt: "2026-08-11T08:05:00+02:00",
+};
+
+test("profile protocol smoke test uses fresh timing children and excludes diagnostics from v2 medians", () => {
+  const parsed = parseScheduledMeetingRequest(REQUEST);
+  assert.equal(parsed.success, true);
+  if (!parsed.success) throw new Error("Fixture profile request unexpectedly failed validation.");
+
+  const launches: ChildRunRequest[] = [];
+  const collection = collectProfileSamples({
+    cpuProfile: true,
+    heapSnapshots: false,
+    runChild(request) {
+      launches.push(request);
+      return fixtureChildReport(parsed.data, request, 10_000 + request.sample);
+    },
+  });
+
+  assert.deepEqual(launches, [
+    { sample: 1, diagnostic: false, cpuProfile: false, heapSnapshots: false },
+    { sample: 2, diagnostic: false, cpuProfile: false, heapSnapshots: false },
+    { sample: 3, diagnostic: false, cpuProfile: false, heapSnapshots: false },
+    { sample: 4, diagnostic: true, cpuProfile: true, heapSnapshots: false },
+  ]);
+  assert.deepEqual(collection.timingSamples.map((sample) => sample.report.processId), [10_001, 10_002, 10_003]);
+  assert.equal(collection.diagnosticSample?.report.processId, 10_004);
+
+  const aggregate = aggregateProfile(collection);
+  assert.equal(aggregate.contractVersion, "meeet-calculation-profile/v2");
+  assert.equal(aggregate.requestTimings.sampleCount, 3);
+  assert.equal(aggregate.requestTimings.firstRequestMedianMs, 12);
+  assert.equal(aggregate.requestTimings.warmRequestMedianMs, 7);
+  assert.equal(aggregate.stages.firstRequest.every((stage) => stage.sampleCount === 3), true);
+  assert.equal(aggregate.stages.warmRequest.every((stage) => stage.sampleCount === 3), true);
+  assert.equal(aggregate.diagnostics?.sample, 4);
+  assert.equal(aggregate.diagnostics?.cpuProfilePath !== null, true);
+  assert.deepEqual(aggregate.artifact.sampleCompiledArtifactIds, [
+    FIXTURE_SCHEDULED_ARTIFACT.provenance.compiledArtifactId,
+    FIXTURE_SCHEDULED_ARTIFACT.provenance.compiledArtifactId,
+    FIXTURE_SCHEDULED_ARTIFACT.provenance.compiledArtifactId,
+  ]);
+  assert.deepEqual(aggregate.request, parsed.data);
+  assert.equal(aggregate.accessProvider.name, FIXTURE_SCHEDULED_ACCESS_PROVIDER.descriptor.name);
+
+  const launch = buildWorkerLaunch({
+    nodePath: "/node",
+    tsxCliPath: "/repo/node_modules/tsx/dist/cli.mjs",
+    workerPath: "/repo/scripts/profile-scheduled-calculation-worker.ts",
+    outputPath: "/tmp/sample.json",
+    request: { sample: 4, diagnostic: true, cpuProfile: true, heapSnapshots: true },
+  });
+  assert.equal(launch.command, "/node");
+  assert.deepEqual(launch.args, [
+    "--conditions=react-server",
+    "/repo/node_modules/tsx/dist/cli.mjs",
+    "/repo/scripts/profile-scheduled-calculation-worker.ts",
+    "--sample",
+    "4",
+    "--output",
+    "/tmp/sample.json",
+    "--diagnostic",
+    "--inspector-cpu",
+    "--heap-snapshots",
+  ]);
+});
+
+test("profile protocol rejects unstable provenance and process reuse", () => {
+  const parsed = parseScheduledMeetingRequest(REQUEST);
+  assert.equal(parsed.success, true);
+  if (!parsed.success) return;
+  assert.throws(() => collectProfileSamples({
+    cpuProfile: false,
+    heapSnapshots: false,
+    runChild(request) {
+      return fixtureChildReport(parsed.data, request, 20_000 + request.sample, request.sample === 2 ? "tampered-artifact" : undefined);
+    },
+  }), /artifact, request, or access-provider provenance/);
+
+  assert.throws(() => collectProfileSamples({
+    cpuProfile: false,
+    heapSnapshots: false,
+    runChild(request) {
+      return fixtureChildReport(parsed.data, request, 20_001);
+    },
+  }), /distinct child processes/);
+});
+
+test("profile protocol rejects malformed reports and incomplete stage sets", () => {
+  const parsed = parseScheduledMeetingRequest(REQUEST);
+  assert.equal(parsed.success, true);
+  if (!parsed.success) return;
+  assert.throws(() => collectProfileSamples({
+    cpuProfile: false,
+    heapSnapshots: false,
+    runChild(request) {
+      const report = fixtureChildReport(parsed.data, request, 30_000 + request.sample);
+      return request.sample === 2 ? { ...report, stages: report.stages.slice(0, -1) } : report;
+    },
+  }), /malformed/);
+  assert.throws(() => collectProfileSamples({
+    cpuProfile: false,
+    heapSnapshots: false,
+    runChild(request) {
+      const report = fixtureChildReport(parsed.data, request, 31_000 + request.sample);
+      return request.sample === 1 ? { ...report, request: { ...report.request, tolerancePercent: 5 } } : report;
+    },
+  }), /malformed|provenance/);
+});
+
+function fixtureChildReport(
+  request: ScheduledMeetingRequest,
+  run: ChildRunRequest,
+  processId: number,
+  artifactId = FIXTURE_SCHEDULED_ARTIFACT.provenance.compiledArtifactId,
+): ChildProfileReport {
+  const firstRequest = requestMeasurement(run.sample, "first", 12);
+  const warmRequest = requestMeasurement(run.sample, "warm", 7);
+  const stages: StageMeasurement[] = EXPECTED_CALCULATION_STAGES.flatMap((stage, index) => [
+    { stage, requestKind: "first" as const, elapsedMs: index, heapDeltaBytes: index },
+    { stage, requestKind: "warm" as const, elapsedMs: index, heapDeltaBytes: index },
+  ]);
+  return {
+    contractVersion: "meeet-calculation-profile-child/v2",
+    nodeVersion: "24.19.0",
+    processId,
+    diagnostic: run.diagnostic,
+    request,
+    accessProvider: FIXTURE_SCHEDULED_ACCESS_PROVIDER.descriptor,
+    artifact: {
+      path: "/fixture/scheduled-artifact.json",
+      compiledArtifactId: artifactId,
+      feedId: FIXTURE_SCHEDULED_ARTIFACT.feedId,
+      serviceDateRange: FIXTURE_SCHEDULED_ARTIFACT.serviceDateRange,
+      stationAreaCount: FIXTURE_SCHEDULED_ARTIFACT.stationAreas.length,
+      connectionCount: FIXTURE_SCHEDULED_ARTIFACT.connections.length,
+    },
+    artifactLoad: { elapsedMs: 4, heapDeltaBytes: 100 },
+    firstRequest,
+    warmRequest,
+    stages,
+    cpuProfilePath: run.cpuProfile ? "/profiles/diagnostic.cpuprofile" : null,
+    heapSnapshotPath: run.heapSnapshots ? "/profiles/diagnostic.heapsnapshot" : null,
+  };
+}
+
+function requestMeasurement(sample: number, requestKind: "first" | "warm", elapsedMs: number) {
+  return {
+    sample,
+    requestKind,
+    elapsedMs,
+    calculationElapsedMs: elapsedMs,
+    validationElapsedMs: 1,
+    serializationElapsedMs: 1,
+    heapDeltaBytes: 100,
+    status: "ok" as const,
+    reason: null,
+    validationSuccess: true,
+    validationIssues: null,
+    serializedByteLength: 100,
+    stationAreaCatalogEntryCount: 3,
+  };
+}

--- a/test/scheduled-calculation-stages.test.ts
+++ b/test/scheduled-calculation-stages.test.ts
@@ -11,7 +11,7 @@ import {
 } from "../lib/fixtures/scheduled-routing.ts";
 import { parseScheduledMeetingRequest } from "../lib/validation/meeting-v3.ts";
 
-// This literal MUST mirror the fixed REQUEST in scripts/profile-scheduled-calculation.ts
+// This literal MUST mirror the fixed REQUEST in scripts/profile-scheduled-calculation-worker.ts
 // (same participant origins — labels need not match — plus tolerancePercent,
 // changeTimePreset, and searchStartAt) so the stage-order test stays comparable
 // to the profiling baseline.

--- a/test/scheduled-routing-phase2.test.ts
+++ b/test/scheduled-routing-phase2.test.ts
@@ -19,6 +19,7 @@ import {
 } from "../lib/validation/meeting-v3.ts";
 import {
   calculateScheduledMeeting,
+  calculateScheduledMeetingWithBasis,
   type ScheduledMeetingProviderBundle,
 } from "../lib/domain/scheduled-routing/meeting.ts";
 import {
@@ -33,7 +34,10 @@ import { fixtureProviders } from "../lib/fixtures/providers.ts";
 import type { MeetingProviders } from "../lib/domain/providers.ts";
 import { compareScheduledIds, importGtfsSchedule, type GtfsFeedFiles } from "../lib/domain/scheduled-routing/gtfs.ts";
 import type { ScheduledRoutingArtifact } from "../lib/domain/scheduled-routing/models.ts";
-import { buildScheduledStationAreaCatalog } from "../lib/domain/scheduled-routing/surface.ts";
+import {
+  buildScheduledStationAreaCatalog,
+  clearScheduledStationAreaCatalogCache,
+} from "../lib/domain/scheduled-routing/surface.ts";
 import { createMeetingProviders } from "../lib/providers/factory.ts";
 import { MVG_NEARBY_URL } from "../lib/providers/mvg-constants.ts";
 import { ScheduledCalculationDeadlineError } from "../lib/domain/scheduled-admission.ts";
@@ -679,6 +683,83 @@ test("v3 response validation derives exact station-area classification and rejec
   oneSidedArea.fasterParticipant = null;
   oneSidedArea.withinSelectedTolerance = false;
   assert.equal(validateScheduledMeetingResponse(oneSidedTamper, parsed.data).success, false);
+});
+
+test("station-area catalogs are cached by artifact object and shared by strict validation", async () => {
+  clearScheduledStationAreaCatalogCache();
+  const artifact = stationAreaMeetingArtifact();
+  const catalog = buildScheduledStationAreaCatalog(artifact);
+  assert.equal(Object.isFrozen(catalog), true);
+  assert.equal(Object.isFrozen(catalog.entries), true);
+  const catalogEntry = catalog.entries[0];
+  assert.ok(catalogEntry !== undefined);
+  assert.equal(Object.isFrozen(catalogEntry), true);
+  assert.equal(Object.isFrozen(catalogEntry.coordinate), true);
+  const originalEntryName = catalogEntry.name;
+  const originalLatitude = catalogEntry.coordinate.latitude;
+  assert.throws(() => {
+    (catalogEntry as unknown as { name: string }).name = "Tampered catalog name";
+  }, TypeError);
+  assert.throws(() => {
+    (catalogEntry.coordinate as unknown as { latitude: number }).latitude = 0;
+  }, TypeError);
+  assert.equal(catalogEntry.name, originalEntryName);
+  assert.equal(catalogEntry.coordinate.latitude, originalLatitude);
+  assert.strictEqual(buildScheduledStationAreaCatalog(artifact), catalog);
+
+  const replacementArtifact: ScheduledRoutingArtifact = { ...artifact };
+  const replacementCatalog = buildScheduledStationAreaCatalog(replacementArtifact);
+  assert.equal(replacementArtifact.provenance.compiledArtifactId, artifact.provenance.compiledArtifactId);
+  assert.deepEqual(replacementCatalog, catalog);
+  assert.notStrictEqual(replacementCatalog, catalog);
+
+  const parsed = parseScheduledMeetingRequest(V3_REQUEST);
+  assert.equal(parsed.success, true);
+  if (!parsed.success) return;
+  const firstCalculation = await calculateScheduledMeetingWithBasis(parsed.data, {
+    artifact,
+    access: stationAreaMeetingAccessProvider(),
+  });
+  const secondCalculation = await calculateScheduledMeetingWithBasis(parsed.data, {
+    artifact,
+    access: stationAreaMeetingAccessProvider(),
+  });
+  assert.strictEqual(firstCalculation.stationAreaCatalog, secondCalculation.stationAreaCatalog);
+  assert.equal(validateScheduledMeetingResponse(firstCalculation.response, parsed.data, {
+    stationAreaCatalog: firstCalculation.stationAreaCatalog,
+  }).success, true);
+  assert.equal(validateScheduledMeetingResponse(secondCalculation.response, parsed.data, {
+    stationAreaCatalog: secondCalculation.stationAreaCatalog,
+  }).success, true);
+});
+
+test("station-area catalog cache preserves its immediate deadline checkpoint and does not publish interrupted builds", () => {
+  clearScheduledStationAreaCatalogCache();
+  const artifact = stationAreaMeetingArtifact();
+  const baseCatalog = buildScheduledStationAreaCatalog(artifact);
+  let cacheHitCheckpoints = 0;
+  buildScheduledStationAreaCatalog(artifact, () => {
+    cacheHitCheckpoints += 1;
+  });
+  assert.equal(cacheHitCheckpoints, 1);
+
+  const expandedArtifact: ScheduledRoutingArtifact = {
+    ...artifact,
+    stationAreas: Array.from({ length: 33 }, (_, index) => artifact.stationAreas[index % artifact.stationAreas.length]!),
+  };
+  let interruptedCheckpoints = 0;
+  assert.throws(() => buildScheduledStationAreaCatalog(expandedArtifact, () => {
+    interruptedCheckpoints += 1;
+    if (interruptedCheckpoints === 2) throw new Error("deadline");
+  }), /deadline/);
+  assert.equal(interruptedCheckpoints, 2);
+  interruptedCheckpoints = 0;
+  const fullCatalog = buildScheduledStationAreaCatalog(expandedArtifact, () => {
+    interruptedCheckpoints += 1;
+  });
+  assert.equal(interruptedCheckpoints, 2);
+  const expectedEntryCount = expandedArtifact.stationAreas.filter((area) => baseCatalog.entries.some((entry) => entry.stationAreaId === area.id)).length;
+  assert.equal(fullCatalog.entries.length, expectedEntryCount);
 });
 
 test("v3 response validation rejects arrival and access seconds that are not minute-aligned", async () => {


### PR DESCRIPTION
## Summary
- cache the immutable Munich station-area catalog per compiled artifact
- preserve strict validation through the shared catalog
- profile fresh first and warm requests against the same real artifact

## Validation
- npm run lint
- npx tsc --noEmit
- npm test

Closes #90