### PR TITLE
perf(scheduled): batch canonical artifact hashing

### DIFF
--- a/docs/profiling/issue-94-batched-canonical-hashing.md
+++ b/docs/profiling/issue-94-batched-canonical-hashing.md
@@ -1,0 +1,54 @@
+# Issue #94 — batched canonical artifact hashing
+
+## Measurement protocol
+
+One downloaded 17,679,535-byte live MVV `20260803` archive was compiled by
+`dev` (unbatched) and by `feature/94-batch-canonical-artifact-hashing` (batched),
+using Node 24.19.0. Each side used three fresh-process successful runs of the
+fixed profiling harness request: red `(48.1374, 11.5755)`, blue `(48.14,
+11.57)`, tolerance 10%, medium change time, and
+`2026-08-11T08:05:00+02:00`. Values below are medians in milliseconds; Δ is
+after − before.
+
+The acquisition timestamp was controlled by recomputing the after hash with
+the feature code over the exact decoded artifact produced by `dev`. It exactly
+matched the manifest `compiledArtifactId`, so both paths identify the same real
+artifact:
+
+- `contentHash`: `4e5e78f8a99fa6b4955cf4cff8a1cacba98d939afe9dc80f8383a811f91f5550`
+- `compiledArtifactId`: `88e0e6b01a3f92900c37fd6b2992601b8600551d207e78bd843396ead691512d`
+- payload: 808,821,104 bytes
+- counts: 898 routes, 114,360 trips, 9,313 station areas, 2,075,789 connections
+
+## Per-stage medians (ms)
+
+| Stage | Before | After | Δ |
+| --- | ---: | ---: | ---: |
+| artifact-load | 18,278 | 11,772 | **−6,506** |
+| access-seeds | 494 | 2,357 | +1,863 |
+| station-area-catalog | 1,532 | 1,453 | −79 |
+| routing-window | 711 | 613 | −98 |
+| scan-red | 0 | 0 | 0 |
+| scan-blue | 1,667 | 1,569 | −98 |
+| participant-surfaces | 0 | 0 | 0 |
+| station-area-evaluation | 1 | 1 | 0 |
+| response-build | 0 | 0 | 0 |
+| validation | 1,826 | 1,712 | −114 |
+| serialization | 0 | 0 | 0 |
+| **total** | **24,442** | **19,404** | **−5,038** |
+
+The cold-load median is the evidence attributable to batching: canonical
+identity recomputation occurs during artifact load, and it fell by 6,506 ms.
+The total also includes unrelated stages; in particular, access-seed timing
+includes live MVG variance. The other stage deltas should therefore not be
+attributed to this change.
+
+The deterministic fixture identity test separately asserts the known
+pre-change content hash and compiled artifact ID. The UTF-8 regression fixture
+leaves one byte before the 64 KiB batch boundary, then supplies a four-byte
+emoji, forcing a flush before the emoji and checking the expected canonical
+hash. Existing loader tests separately cover truncated and substituted payload
+tampering, manifest compiled-ID mismatch, and raw-archive identity mismatch.
+
+`git diff --check`: passed. Full-suite validation is owned by the parent
+orchestrator.

--- a/lib/domain/scheduled-routing/gtfs.ts
+++ b/lib/domain/scheduled-routing/gtfs.ts
@@ -935,35 +935,95 @@ function sha256(value: string): string {
 
 function sha256Canonical(value: unknown): string {
   const hash = createHash("sha256");
-  writeCanonicalJson(hash, value);
+  const writer = new CanonicalHashWriter(hash);
+  writeCanonicalJson(writer, value);
+  writer.flush();
   return hash.digest("hex");
 }
 
-function writeCanonicalJson(hash: Hash, value: unknown): void {
+const CANONICAL_HASH_BATCH_BYTES = 64 * 1024;
+
+/** Batches canonical JSON without materializing the complete serialized value. */
+class CanonicalHashWriter {
+  private readonly chunks: string[] = [];
+  private pendingBytes = 0;
+
+  constructor(private readonly hash: Hash) {}
+
+  write(value: string): void {
+    let offset = 0;
+    while (offset < value.length) {
+      const availableBytes = CANONICAL_HASH_BATCH_BYTES - this.pendingBytes;
+      if (availableBytes === 0) {
+        this.flush();
+        continue;
+      }
+
+      if (offset === 0) {
+        const valueBytes = Buffer.byteLength(value, "utf8");
+        if (valueBytes <= availableBytes) {
+          this.chunks.push(value);
+          this.pendingBytes += valueBytes;
+          return;
+        }
+      }
+
+      let end = offset;
+      let chunkBytes = 0;
+      while (end < value.length) {
+        const codePoint = value.codePointAt(end);
+        if (codePoint === undefined) break;
+        const codeUnitLength = codePoint > 0xffff ? 2 : 1;
+        const codePointBytes = codePoint <= 0x7f ? 1 : codePoint <= 0x7ff ? 2 : codePoint <= 0xffff ? 3 : 4;
+        if (chunkBytes + codePointBytes > availableBytes) break;
+        chunkBytes += codePointBytes;
+        end += codeUnitLength;
+      }
+
+      if (end === offset) {
+        this.flush();
+        continue;
+      }
+      this.chunks.push(value.slice(offset, end));
+      this.pendingBytes += chunkBytes;
+      offset = end;
+      if (this.pendingBytes === CANONICAL_HASH_BATCH_BYTES) this.flush();
+    }
+  }
+
+  flush(): void {
+    if (this.pendingBytes === 0) return;
+    this.hash.update(this.chunks.join(""), "utf8");
+    this.chunks.length = 0;
+    this.pendingBytes = 0;
+  }
+}
+
+function writeCanonicalJson(writer: CanonicalHashWriter, value: unknown): void {
   if (value === null || typeof value === "string" || typeof value === "number" || typeof value === "boolean") {
     const encoded = JSON.stringify(value);
     if (encoded === undefined) throw new TypeError("Cannot hash an unsupported provenance value.");
-    hash.update(encoded, "utf8");
+    writer.write(encoded);
     return;
   }
   if (Array.isArray(value)) {
-    hash.update("[", "utf8");
+    writer.write("[");
     value.forEach((entry, index) => {
-      if (index > 0) hash.update(",", "utf8");
-      writeCanonicalJson(hash, entry);
+      if (index > 0) writer.write(",");
+      writeCanonicalJson(writer, entry);
     });
-    hash.update("]", "utf8");
+    writer.write("]");
     return;
   }
   if (typeof value === "object" && value !== null) {
-    hash.update("{", "utf8");
+    writer.write("{");
     Object.keys(value).sort((left, right) => left.localeCompare(right)).forEach((key, index) => {
-      if (index > 0) hash.update(",", "utf8");
-      hash.update(JSON.stringify(key), "utf8");
-      hash.update(":", "utf8");
-      writeCanonicalJson(hash, (value as Record<string, unknown>)[key]);
+      if (index > 0) writer.write(",");
+      writer.write(JSON.stringify(key));
+      writer.write(":");
+      writeCanonicalJson(writer, (value as Record<string, unknown>)[key]);
     });
-    hash.update("}", "utf8");
+    writer.write("}");
     return;
   }
   throw new TypeError("Cannot hash an unsupported provenance value.");

--- a/test/scheduled-routing.test.ts
+++ b/test/scheduled-routing.test.ts
@@ -3,6 +3,8 @@ import test from "node:test";
 
 import {
   addServiceDays,
+  calculateScheduledCompiledArtifactId,
+  calculateScheduledContentHash,
   calculateScheduledSurface,
   compareScheduledConnections,
   importGtfsSchedule,
@@ -243,6 +245,26 @@ test("GTFS import validates station areas, IDs, coordinates, columns, and freeze
   assert.throws(() => importFixtureFiles(badCoordinate), /coordinate bounds/);
   const badParent = { ...FIXTURE_FILES, "stops.txt": FIXTURE_FILES["stops.txt"].replace("station-b\n", "missing-parent\n") };
   assert.throws(() => importFixtureFiles(badParent), /parent_station/);
+});
+
+test("batched canonical hashing preserves the pre-change fixture identity", () => {
+  const expectedContentHash = "eba14665b5b4b7ebe538a981b28dc3cd56a0a818d9fe2cb5b7d62515c12c9084";
+  const expectedCompiledArtifactId = "94c2776a25c095fdcebb85a47e26322dd95deaaf7c8952e5ef3b176923d0d51e";
+  const { provenance, ...core } = FIXTURE_SCHEDULED_ARTIFACT;
+  const { compiledArtifactId, ...identity } = provenance;
+
+  assert.equal(calculateScheduledContentHash(identity.feedId, identity.timeZone, identity.files), expectedContentHash);
+  assert.equal(identity.contentHash, expectedContentHash);
+  assert.equal(calculateScheduledCompiledArtifactId(core, identity), expectedCompiledArtifactId);
+  assert.equal(compiledArtifactId, expectedCompiledArtifactId);
+});
+
+test("batched canonical hashing preserves UTF-8 bytes across a chunk boundary", () => {
+  const files = [{ fileName: `${"x".repeat(65_470)}😀`, sha256: "b".repeat(64), byteLength: 123 }];
+  assert.equal(
+    calculateScheduledContentHash("batch-fixture", "Europe/Berlin", files),
+    "bc5ef0a390e1d974edcdf4d34e55bef64b033c51a65041b9c07ef7612446e26c",
+  );
 });
 
 test("GTFS importer accepts a BOM immediately before a quoted header and quoted CSV values", () => {


### PR DESCRIPTION
## Summary
- batch canonical JSON hash input without materializing full artifacts
- lock fixture and real-artifact identity parity, including a UTF-8 boundary seam
- record matched three-run Node 24 cold-load profiling evidence

## Validation
- `npx --yes node@24 ./node_modules/tsx/dist/cli.mjs --test --import ./test/server-only-register.mjs test/*.test.ts`
- `npx --yes node@24 ./node_modules/typescript/bin/tsc --noEmit`
- `npx --yes node@24 ./node_modules/eslint/bin/eslint.js`
- `git diff --check`

Closes #94