### PR TITLE
perf: avoid artifact key-array allocations

### DIFF
--- a/docs/profiling/issue-93-strict-key-validation.md
+++ b/docs/profiling/issue-93-strict-key-validation.md
@@ -1,0 +1,22 @@
+# Issue #93 — strict key validation performance
+
+Measured with Node 24.19.0 using three fresh Node processes per variant. Every run
+used the identical real artifact `9f48cda6cf35b78e1aa6d16d330218134651067a1c2f1c45be80bd9a08b42b6e`
+(feed `20260803`, 9,313 station areas, 2,075,789 connections, payload
+808,821,104 bytes) and the standard fixed harness request (red `48.1374,11.5755`,
+blue `48.14,11.57`, tolerance 10%, search start
+`2026-08-11T08:05:00+02:00`). No artifact was recompiled between variants.
+
+For the before measurement only, the old sorted `hasExactKeys` implementation was
+temporarily reinstated and then restored. A fresh process makes the application
+cache cold; the OS file cache was not intentionally dropped.
+
+## Results (milliseconds)
+
+| Measurement | Before runs | Before median | After runs | After median | Delta |
+| --- | ---: | ---: | ---: | ---: | ---: |
+| artifact-load | 18,353 / 18,044 / 18,006 | 18,044 | 16,808 / 16,923 / 17,030 | 16,923 | −1,121 (−6.2%) |
+| Total | 24,326 / 23,829 / 23,768 | 23,829 | 22,749 / 22,585 / 22,557 | 22,585 | −1,244 (−5.2%) |
+
+The total includes work outside strict key validation, so its reduction should not be
+attributed entirely to this change.

--- a/docs/profiling/issue-93-strict-key-validation.md
+++ b/docs/profiling/issue-93-strict-key-validation.md
@@ -15,8 +15,8 @@ cache cold; the OS file cache was not intentionally dropped.
 
 | Measurement | Before runs | Before median | After runs | After median | Delta |
 | --- | ---: | ---: | ---: | ---: | ---: |
-| artifact-load | 18,353 / 18,044 / 18,006 | 18,044 | 16,808 / 16,923 / 17,030 | 16,923 | −1,121 (−6.2%) |
-| Total | 24,326 / 23,829 / 23,768 | 23,829 | 22,749 / 22,585 / 22,557 | 22,585 | −1,244 (−5.2%) |
+| artifact-load | 18,353 / 18,044 / 18,006 | 18,044 | 16,753 / 16,712 / 17,045 | 16,753 | −1,291 (−7.2%) |
+| Total | 24,326 / 23,829 / 23,768 | 23,829 | 22,448 / 22,641 / 24,216 | 22,641 | −1,188 (−5.0%) |
 
 The total includes work outside strict key validation, so its reduction should not be
 attributed entirely to this change.

--- a/docs/profiling/issue-93-strict-key-validation.md
+++ b/docs/profiling/issue-93-strict-key-validation.md
@@ -1,22 +1,26 @@
 # Issue #93 — strict key validation performance
 
-Measured with Node 24.19.0 using three fresh Node processes per variant. Every run
-used the identical real artifact `9f48cda6cf35b78e1aa6d16d330218134651067a1c2f1c45be80bd9a08b42b6e`
-(feed `20260803`, 9,313 station areas, 2,075,789 connections, payload
-808,821,104 bytes) and the standard fixed harness request (red `48.1374,11.5755`,
-blue `48.14,11.57`, tolerance 10%, search start
-`2026-08-11T08:05:00+02:00`). No artifact was recompiled between variants.
+Final controlled measurement after merging dev’s issue #94 batching work, using Node
+24.19.0 and profiling harness v2. The harness launched exactly three fresh child
+processes per variant. Both variants used the identical real artifact
+`9f48cda6cf35b78e1aa6d16d330218134651067a1c2f1c45be80bd9a08b42b6e` (feed `20260803`,
+9,313 station areas, 2,075,789 connections, payload 808,821,104 bytes) and the
+standard fixed request: red `48.1374,11.5755`, blue `48.14,11.57`, tolerance 10%,
+search start `2026-08-11T08:05:00+02:00`. No artifact was recompiled.
 
-For the before measurement only, the old sorted `hasExactKeys` implementation was
-temporarily reinstated and then restored. A fresh process makes the application
-cache cold; the OS file cache was not intentionally dropped.
+For the baseline only, `lib/domain/scheduled-routing/artifact.ts` was restored from
+current `origin/dev` (post-#94, without #93), then the final implementation was
+restored. The OS file cache was not dropped. The v2 request timer starts after
+artifact load, so only `artifact-load` is attributable to this change.
 
-## Results (milliseconds)
+## Median results (milliseconds)
 
-| Measurement | Before runs | Before median | After runs | After median | Delta |
-| --- | ---: | ---: | ---: | ---: | ---: |
-| artifact-load | 18,353 / 18,044 / 18,006 | 18,044 | 16,753 / 16,712 / 17,045 | 16,753 | −1,291 (−7.2%) |
-| Total | 24,326 / 23,829 / 23,768 | 23,829 | 22,448 / 22,641 / 24,216 | 22,641 | −1,188 (−5.0%) |
+| Measurement | Before | After | Delta |
+| --- | ---: | ---: | ---: |
+| artifact-load | 13,077 | 12,546 | −531 (−4.1%) |
+| first request | 5,197 | 5,026 | −171 (−3.3%) |
+| warm request | 2,038 | 1,963 | −75 (−3.7%) |
 
-The total includes work outside strict key validation, so its reduction should not be
-attributed entirely to this change.
+The first- and warm-request deltas include unrelated calculation and access variance
+and are not attributable to issue #93. Ignored reports: `profiles/report-9f48cda6cf35-2026-08-21T14-18-19.890Z.json`
+and `profiles/report-9f48cda6cf35-2026-08-21T14-19-25.963Z.json`.

--- a/lib/domain/scheduled-routing/artifact.ts
+++ b/lib/domain/scheduled-routing/artifact.ts
@@ -40,6 +40,26 @@ const MAX_BUNDLE_MANIFEST_BYTES = 1 * 1024 * 1024;
 const MAX_BUNDLE_PAYLOAD_BYTES = 1 * 1024 * 1024 * 1024;
 const loadedScheduledArtifacts = new Map<string, ScheduledRoutingArtifact>();
 
+const BUNDLE_MANIFEST_KEYS = ["contractVersion", "encoding", "writerNodeMajor", "payloadFile", "payloadByteLength", "payloadSha256", "compiledArtifactId", "summary", "provenance", "compilerVersion"] as const;
+const LEGACY_BUNDLE_MANIFEST_KEYS = ["contractVersion", "encoding", "writerNodeMajor", "payloadFile", "payloadByteLength", "payloadSha256", "compiledArtifactId", "summary", "provenance"] as const;
+const BUNDLE_SUMMARY_KEYS = ["feedId", "timeZone", "serviceDateRange", "maximumServiceDayTimeSeconds", "searchStartBounds", "counts"] as const;
+const BUNDLE_COUNTS_KEYS = ["routes", "trips", "stationAreas", "calendars", "exceptions", "connections"] as const;
+const PROVENANCE_KEYS = ["hashAlgorithm", "contentHash", "feedId", "timeZone", "files", "acquisition", "compiledArtifactId"] as const;
+const FILE_PROVENANCE_KEYS = ["fileName", "sha256", "byteLength"] as const;
+const ACQUISITION_KEYS = ["sourceUrl", "retrievedAt", "rawArchiveByteSize", "rawArchiveSha256", "feedVersion", "feedValidFrom", "feedValidUntil", "attribution", "officialAttribution", "officialLicense", "officialProvenance"] as const;
+const LICENSE_KEYS = ["name", "url"] as const;
+const OFFICIAL_PROVENANCE_KEYS = ["source", "policyId"] as const;
+const DATE_RANGE_KEYS = ["firstDate", "lastDate"] as const;
+const SEARCH_START_BOUNDS_KEYS = ["earliestEpochSeconds", "latestEpochSeconds", "earliestAt", "latestAt", "maximumServiceDayTimeSeconds"] as const;
+const SCHEDULED_ARTIFACT_CORE_KEYS = ["contractVersion", "feedId", "timeZone", "maximumServiceDayTimeSeconds", "searchStartBounds", "serviceDateRange", "routes", "trips", "stationAreas", "calendars", "exceptions", "connections"] as const;
+const ROUTE_KEYS = ["routeId", "shortName", "longName", "routeType"] as const;
+const TRIP_KEYS = ["tripId", "routeId", "serviceId", "headsign"] as const;
+const STATION_AREA_KEYS = ["id", "name", "coordinate", "mode", "transferNeighbors"] as const;
+const CALENDAR_KEYS = ["serviceId", "startDate", "endDate", "weekdays"] as const;
+const EXCEPTION_KEYS = ["serviceId", "date", "exceptionType"] as const;
+const CONNECTION_KEYS = ["id", "tripId", "routeId", "serviceId", "fromStationAreaId", "toStationAreaId", "fromStopSequence", "toStopSequence", "departureTimeSeconds", "arrivalTimeSeconds", "pickupType", "dropOffType", "line"] as const;
+const TRANSFER_NEIGHBOR_KEYS = ["stationAreaId", "distanceMeters"] as const;
+
 interface ScheduledBundleCounts {
   readonly routes: number;
   readonly trips: number;
@@ -418,11 +438,11 @@ function readBundleManifest(path: string): ScheduledBundleManifest {
 
 function isBundleManifest(value: unknown): value is ScheduledBundleManifest {
   if (!isRecord(value) ||
-    (!hasExactKeys(value, ["contractVersion", "encoding", "writerNodeMajor", "payloadFile", "payloadByteLength", "payloadSha256", "compiledArtifactId", "summary", "provenance", "compilerVersion"]) &&
-      !hasExactKeys(value, ["contractVersion", "encoding", "writerNodeMajor", "payloadFile", "payloadByteLength", "payloadSha256", "compiledArtifactId", "summary", "provenance"])) ||
+    (!hasExactKeys(value, BUNDLE_MANIFEST_KEYS) &&
+      !hasExactKeys(value, LEGACY_BUNDLE_MANIFEST_KEYS)) ||
     (value.compilerVersion !== undefined && !isCompilerVersion(value.compilerVersion))) return false;
   const summary = value.summary;
-  if (!isRecord(summary) || !hasExactKeys(summary, ["feedId", "timeZone", "serviceDateRange", "maximumServiceDayTimeSeconds", "searchStartBounds", "counts"])) return false;
+  if (!isRecord(summary) || !hasExactKeys(summary, BUNDLE_SUMMARY_KEYS)) return false;
   const counts = summary.counts;
   return value.contractVersion === SCHEDULED_BUNDLE_CONTRACT_VERSION &&
     value.encoding === SCHEDULED_BUNDLE_ENCODING &&
@@ -432,7 +452,7 @@ function isBundleManifest(value: unknown): value is ScheduledBundleManifest {
     isSha256(value.payloadSha256) && isSha256(value.compiledArtifactId) && isStrictProvenance(value.provenance) &&
     isString(summary.feedId) && summary.timeZone === "Europe/Berlin" && isStrictDateRange(summary.serviceDateRange) &&
     isSafeInteger(summary.maximumServiceDayTimeSeconds) && isStrictSearchStartBounds(summary.searchStartBounds) &&
-    isRecord(counts) && hasExactKeys(counts, ["routes", "trips", "stationAreas", "calendars", "exceptions", "connections"]) &&
+    isRecord(counts) && hasExactKeys(counts, BUNDLE_COUNTS_KEYS) &&
     Object.values(counts).every((count) => isSafeInteger(count) && count >= 0);
 }
 
@@ -449,32 +469,32 @@ function isCompilerVersion(value: unknown): value is string {
 }
 
 function isStrictProvenance(value: unknown): value is ScheduledRoutingArtifact["provenance"] {
-  if (!isRecord(value) || !hasExactKeys(value, ["hashAlgorithm", "contentHash", "feedId", "timeZone", "files", "acquisition", "compiledArtifactId"]) ||
+  if (!isRecord(value) || !hasExactKeys(value, PROVENANCE_KEYS) ||
     value.hashAlgorithm !== "sha256" || !isSha256(value.contentHash) || !isString(value.feedId) || value.timeZone !== "Europe/Berlin" || !isSha256(value.compiledArtifactId) || !Array.isArray(value.files) ||
-    !value.files.every((file) => isRecord(file) && hasExactKeys(file, ["fileName", "sha256", "byteLength"]) && isString(file.fileName) && isSha256(file.sha256) && isSafeInteger(file.byteLength) && file.byteLength >= 0)) return false;
+    !value.files.every((file) => isRecord(file) && hasExactKeys(file, FILE_PROVENANCE_KEYS) && isString(file.fileName) && isSha256(file.sha256) && isSafeInteger(file.byteLength) && file.byteLength >= 0)) return false;
   const acquisition = value.acquisition;
-  if (!isRecord(acquisition) || !hasExactKeys(acquisition, ["sourceUrl", "retrievedAt", "rawArchiveByteSize", "rawArchiveSha256", "feedVersion", "feedValidFrom", "feedValidUntil", "attribution", "officialAttribution", "officialLicense", "officialProvenance"])) return false;
+  if (!isRecord(acquisition) || !hasExactKeys(acquisition, ACQUISITION_KEYS)) return false;
   const license = acquisition.officialLicense;
   const officialProvenance = acquisition.officialProvenance;
   return isString(acquisition.sourceUrl) && isString(acquisition.retrievedAt) && isSafeInteger(acquisition.rawArchiveByteSize) && acquisition.rawArchiveByteSize >= 0 &&
     isSha256(acquisition.rawArchiveSha256) && isString(acquisition.feedVersion) && isDateString(acquisition.feedValidFrom) && isDateString(acquisition.feedValidUntil) &&
-    isString(acquisition.attribution) && isString(acquisition.officialAttribution) && isRecord(license) && hasExactKeys(license, ["name", "url"]) && isString(license.name) && isString(license.url) &&
-    isRecord(officialProvenance) && hasExactKeys(officialProvenance, ["source", "policyId"]) &&
+    isString(acquisition.attribution) && isString(acquisition.officialAttribution) && isRecord(license) && hasExactKeys(license, LICENSE_KEYS) && isString(license.name) && isString(license.url) &&
+    isRecord(officialProvenance) && hasExactKeys(officialProvenance, OFFICIAL_PROVENANCE_KEYS) &&
     (officialProvenance.source === "feed" || officialProvenance.source === "meeet-policy") &&
     (officialProvenance.policyId === null || officialProvenance.policyId === "mvv-cc-by-4.0-fallback/v1");
 }
 
 function isStrictDateRange(value: unknown): value is { readonly firstDate: string; readonly lastDate: string } {
-  return isRecord(value) && hasExactKeys(value, ["firstDate", "lastDate"]) && isDateRange(value);
+  return isRecord(value) && hasExactKeys(value, DATE_RANGE_KEYS) && isDateRange(value);
 }
 
 function isStrictSearchStartBounds(value: unknown): boolean {
-  return isRecord(value) && hasExactKeys(value, ["earliestEpochSeconds", "latestEpochSeconds", "earliestAt", "latestAt", "maximumServiceDayTimeSeconds"]) && isSearchStartBounds(value);
+  return isRecord(value) && hasExactKeys(value, SEARCH_START_BOUNDS_KEYS) && isSearchStartBounds(value);
 }
 
 function isScheduledArtifactCore(value: unknown): value is ScheduledArtifactCore {
   return isRecord(value) &&
-    hasExactKeys(value, ["contractVersion", "feedId", "timeZone", "maximumServiceDayTimeSeconds", "searchStartBounds", "serviceDateRange", "routes", "trips", "stationAreas", "calendars", "exceptions", "connections"]) &&
+    hasExactKeys(value, SCHEDULED_ARTIFACT_CORE_KEYS) &&
     value.contractVersion === SCHEDULED_ROUTING_CONTRACT_VERSION &&
     isString(value.feedId) && value.timeZone === "Europe/Berlin" && isSafeInteger(value.maximumServiceDayTimeSeconds) &&
     isSearchStartBounds(value.searchStartBounds) && isDateRange(value.serviceDateRange) &&
@@ -780,12 +800,12 @@ function isScheduledRoutingArtifact(value: unknown): value is ScheduledRoutingAr
     !Array.isArray(value.routes) ||
     !Array.isArray(value.calendars) ||
     !Array.isArray(value.exceptions) ||
-    !isExactRecordArray(value.routes, ["routeId", "shortName", "longName", "routeType"]) ||
-    !isExactRecordArray(value.trips, ["tripId", "routeId", "serviceId", "headsign"]) ||
-    !isExactRecordArray(value.stationAreas, ["id", "name", "coordinate", "mode", "transferNeighbors"]) ||
-    !isExactRecordArray(value.calendars, ["serviceId", "startDate", "endDate", "weekdays"]) ||
-    !isExactRecordArray(value.exceptions, ["serviceId", "date", "exceptionType"]) ||
-    !isExactRecordArray(value.connections, ["id", "tripId", "routeId", "serviceId", "fromStationAreaId", "toStationAreaId", "fromStopSequence", "toStopSequence", "departureTimeSeconds", "arrivalTimeSeconds", "pickupType", "dropOffType", "line"]) ||
+    !isExactRecordArray(value.routes, ROUTE_KEYS) ||
+    !isExactRecordArray(value.trips, TRIP_KEYS) ||
+    !isExactRecordArray(value.stationAreas, STATION_AREA_KEYS) ||
+    !isExactRecordArray(value.calendars, CALENDAR_KEYS) ||
+    !isExactRecordArray(value.exceptions, EXCEPTION_KEYS) ||
+    !isExactRecordArray(value.connections, CONNECTION_KEYS) ||
     !isRecord(provenance)
   ) return false;
   const acquisition = provenance.acquisition;
@@ -794,7 +814,7 @@ function isScheduledRoutingArtifact(value: unknown): value is ScheduledRoutingAr
     isSha256(provenance.contentHash) &&
     isString(provenance.feedId) &&
     provenance.timeZone === "Europe/Berlin" &&
-    isExactRecordArray(provenance.files, ["fileName", "sha256", "byteLength"]) &&
+    isExactRecordArray(provenance.files, FILE_PROVENANCE_KEYS) &&
     isSha256(provenance.compiledArtifactId) &&
     isRecord(acquisition) &&
     acquisition.sourceUrl === SCHEDULED_MVV_FEED_URL &&
@@ -818,7 +838,7 @@ function isScheduledRoutingArtifact(value: unknown): value is ScheduledRoutingAr
 
 function validateArtifactStructure(artifact: ScheduledRoutingArtifact): void {
   if ("boardingStops" in artifact) throw invalidArtifact("boarding stops");
-  if (artifact.routes.some((route) => typeof route.routeId !== "string" || typeof route.shortName !== "string" || typeof route.longName !== "string") || artifact.trips.some((trip) => typeof trip.tripId !== "string" || typeof trip.routeId !== "string" || typeof trip.serviceId !== "string" || typeof trip.headsign !== "string") ||     artifact.stationAreas.some((area) => typeof area.id !== "string" || typeof area.name !== "string" || !isRecord(area.coordinate) || (area.mode !== "sbahn" && area.mode !== "ubahn" && area.mode !== "tram" && area.mode !== "bus") || "boardingStopIds" in area || "parentStationId" in area || !Array.isArray(area.transferNeighbors) || area.transferNeighbors.some((neighbor) => !isRecord(neighbor) || typeof neighbor.stationAreaId !== "string" || typeof neighbor.distanceMeters !== "number" || !Number.isFinite(neighbor.distanceMeters) || neighbor.distanceMeters < 0 || Object.keys(neighbor).length !== 2)) || artifact.calendars.some((calendar) => typeof calendar.serviceId !== "string" || !Array.isArray(calendar.weekdays)) || artifact.exceptions.some((exception) => typeof exception.serviceId !== "string" || typeof exception.date !== "string") || artifact.connections.some((connection) => typeof connection.id !== "string" || typeof connection.tripId !== "string" || typeof connection.routeId !== "string" || typeof connection.serviceId !== "string" || "fromStopId" in connection || "toStopId" in connection || typeof connection.fromStationAreaId !== "string" || typeof connection.toStationAreaId !== "string" || !isRecord(connection.line))) throw invalidArtifact("nested field type");
+  if (artifact.routes.some((route) => typeof route.routeId !== "string" || typeof route.shortName !== "string" || typeof route.longName !== "string") || artifact.trips.some((trip) => typeof trip.tripId !== "string" || typeof trip.routeId !== "string" || typeof trip.serviceId !== "string" || typeof trip.headsign !== "string") ||     artifact.stationAreas.some((area) => typeof area.id !== "string" || typeof area.name !== "string" || !isRecord(area.coordinate) || (area.mode !== "sbahn" && area.mode !== "ubahn" && area.mode !== "tram" && area.mode !== "bus") || "boardingStopIds" in area || "parentStationId" in area || !Array.isArray(area.transferNeighbors) || area.transferNeighbors.some((neighbor) => !isRecord(neighbor) || !hasExactKeys(neighbor, TRANSFER_NEIGHBOR_KEYS) || typeof neighbor.stationAreaId !== "string" || typeof neighbor.distanceMeters !== "number" || !Number.isFinite(neighbor.distanceMeters) || neighbor.distanceMeters < 0)) || artifact.calendars.some((calendar) => typeof calendar.serviceId !== "string" || !Array.isArray(calendar.weekdays)) || artifact.exceptions.some((exception) => typeof exception.serviceId !== "string" || typeof exception.date !== "string") || artifact.connections.some((connection) => typeof connection.id !== "string" || typeof connection.tripId !== "string" || typeof connection.routeId !== "string" || typeof connection.serviceId !== "string" || "fromStopId" in connection || "toStopId" in connection || typeof connection.fromStationAreaId !== "string" || typeof connection.toStationAreaId !== "string" || !isRecord(connection.line))) throw invalidArtifact("nested field type");
   const routeIds = uniqueSorted(artifact.routes.map((route) => route.routeId), "routes");
   uniqueSorted(artifact.trips.map((trip) => trip.tripId), "trips");
   const areaIds = uniqueSorted(artifact.stationAreas.map((area) => area.id), "stationAreas");

--- a/lib/domain/scheduled-routing/artifact.ts
+++ b/lib/domain/scheduled-routing/artifact.ts
@@ -482,9 +482,13 @@ function isScheduledArtifactCore(value: unknown): value is ScheduledArtifactCore
 }
 
 function hasExactKeys(value: Record<string, unknown>, expected: readonly string[]): boolean {
-  const actual = Object.keys(value).sort();
-  const wanted = [...expected].sort();
-  return actual.length === wanted.length && actual.every((key, index) => key === wanted[index]);
+  let actualCount = 0;
+  for (const key in value) {
+    if (!Object.prototype.hasOwnProperty.call(value, key)) continue;
+    if (!expected.includes(key)) return false;
+    actualCount += 1;
+  }
+  return actualCount === expected.length;
 }
 
 function bundleSummary(core: ScheduledArtifactCore): ScheduledBundleSummary {

--- a/test/scheduled-routing-phase2.test.ts
+++ b/test/scheduled-routing-phase2.test.ts
@@ -397,6 +397,26 @@ test("bundle manifest rejects unsafe payload paths and size-limit violations", a
   await rm(directory, { recursive: true, force: true });
 });
 
+test("bundle loader rejects persisted manifests with missing or unexpected enumerable keys", async () => {
+  const artifact = compileScheduledArtifact({ sourceUrl: SCHEDULED_MVV_FEED_URL, rawArchiveBytes: new TextEncoder().encode("manifest-key-tamper"), feedFiles: compilerFeedFiles(), retrievedAt: "2026-08-11T10:00:00Z" });
+  const directory = await mkdtemp(join(tmpdir(), "meeet-manifest-keys-"));
+  const validPath = join(directory, "valid-bundle.json");
+  writeScheduledArtifact(validPath, artifact);
+  const validManifest = JSON.parse(await readFile(validPath, "utf8")) as Record<string, unknown>;
+
+  const missingManifest = { ...validManifest };
+  delete missingManifest.payloadFile;
+  const missingPath = join(directory, "missing-key-bundle.json");
+  await writeFile(missingPath, JSON.stringify(missingManifest), "utf8");
+  assert.throws(() => loadScheduledArtifact(missingPath, { now: "2026-08-11T12:00:00Z" }), ScheduleArtifactUnavailableError);
+
+  const unexpectedPath = join(directory, "unexpected-key-bundle.json");
+  await writeFile(unexpectedPath, JSON.stringify({ ...validManifest, unexpectedKey: true }), "utf8");
+  assert.throws(() => loadScheduledArtifact(unexpectedPath, { now: "2026-08-11T12:00:00Z" }), ScheduleArtifactUnavailableError);
+
+  await rm(directory, { recursive: true, force: true });
+});
+
 test("compiler defaults retrieval provenance to a canonical UTC whole-second instant", () => {
   const artifact = compileScheduledArtifact({
     sourceUrl: SCHEDULED_MVV_FEED_URL,

--- a/test/scheduled-routing-phase2.test.ts
+++ b/test/scheduled-routing-phase2.test.ts
@@ -397,7 +397,7 @@ test("bundle manifest rejects unsafe payload paths and size-limit violations", a
   await rm(directory, { recursive: true, force: true });
 });
 
-test("bundle loader rejects persisted manifests with missing or unexpected enumerable keys", async () => {
+test("bundle loader rejects persisted manifests and provenance records with missing or unexpected enumerable keys", async () => {
   const artifact = compileScheduledArtifact({ sourceUrl: SCHEDULED_MVV_FEED_URL, rawArchiveBytes: new TextEncoder().encode("manifest-key-tamper"), feedFiles: compilerFeedFiles(), retrievedAt: "2026-08-11T10:00:00Z" });
   const directory = await mkdtemp(join(tmpdir(), "meeet-manifest-keys-"));
   const validPath = join(directory, "valid-bundle.json");
@@ -413,6 +413,25 @@ test("bundle loader rejects persisted manifests with missing or unexpected enume
   const unexpectedPath = join(directory, "unexpected-key-bundle.json");
   await writeFile(unexpectedPath, JSON.stringify({ ...validManifest, unexpectedKey: true }), "utf8");
   assert.throws(() => loadScheduledArtifact(unexpectedPath, { now: "2026-08-11T12:00:00Z" }), ScheduleArtifactUnavailableError);
+
+  const validProvenance = validManifest.provenance as Record<string, unknown>;
+  const validFiles = validProvenance.files as Array<Record<string, unknown>>;
+  const firstFile = validFiles[0];
+  assert.ok(firstFile);
+  const persistedManifestWithFile = (file: Record<string, unknown>) => ({
+    ...validManifest,
+    provenance: { ...validProvenance, files: [file, ...validFiles.slice(1)] },
+  });
+
+  const missingFileKey = { ...firstFile };
+  delete missingFileKey.fileName;
+  const missingFileKeyPath = join(directory, "missing-file-key-bundle.json");
+  await writeFile(missingFileKeyPath, JSON.stringify(persistedManifestWithFile(missingFileKey)), "utf8");
+  assert.throws(() => loadScheduledArtifact(missingFileKeyPath, { now: "2026-08-11T12:00:00Z" }), ScheduleArtifactUnavailableError);
+
+  const unexpectedFileKeyPath = join(directory, "unexpected-file-key-bundle.json");
+  await writeFile(unexpectedFileKeyPath, JSON.stringify(persistedManifestWithFile({ ...firstFile, unexpectedKey: true })), "utf8");
+  assert.throws(() => loadScheduledArtifact(unexpectedFileKeyPath, { now: "2026-08-11T12:00:00Z" }), ScheduleArtifactUnavailableError);
 
   await rm(directory, { recursive: true, force: true });
 });


### PR DESCRIPTION
## Summary
- validate persisted artifact keys without allocating or sorting key arrays per record
- preserve strict manifest and provenance tamper rejection coverage
- record the controlled Node 24 cold-load profile delta

## Validation
- Node 24: full test suite (297 passed, 1 skipped)
- Node 24: npx tsc --noEmit
- Node 24: eslint
- three fresh-process profiles on the same real artifact

Closes #93