### PR TITLE
perf(scheduled): freeze artifacts by schema

### DIFF
--- a/docs/profiling/calculation-baseline.md
+++ b/docs/profiling/calculation-baseline.md
@@ -258,30 +258,56 @@ frames map to `file.ts:1`; aggregate by function name, not line.
 
 ## Issue #91 schema-aware artifact freeze profile (2026-08-21)
 
-Three fresh Node 24.19.0 child processes ran the v2 harness after replacing
-generic artifact deep-freezing with schema-aware traversal. The successful
-command was:
+The controlled comparison used the v2 protocol with the same `package-lock.json`
+dependency resolution in two isolated temporary worktrees:
+
+- `origin/dev` baseline at merge-base `6d75b36b829993be9e50a2c47bbaab4cc1abc7ba`
+- current HEAD at `cce19f597de4e2bc2d38da4be286f75b176ef80d`
+
+Each worktree ran `npm ci --no-audit --no-fund`, then ran the identical profile
+command under Node 24.19.0:
 
 ```sh
 NODE_OPTIONS=--conditions=react-server npm exec --yes --package=node@24 -- node --conditions=react-server node_modules/tsx/dist/cli.mjs scripts/profile-scheduled-calculation.ts
 ```
 
-The same real artifact was used for every child:
+The real artifact source was
+`data/scheduled/mvv-scheduled-artifact.json`; byte-identical copies were used
+in both worktrees. Its identity and shape were:
 
-- path: `data/scheduled/mvv-scheduled-artifact.json`
 - `compiledArtifactId`: `88e0e6b01a3f92900c37fd6b2992601b8600551d207e78bd843396ead691512d`
 - payload: `808,821,104` bytes
 - counts: `9,313` station areas and `2,075,789` connections
 
-Raw cold-load measurements from
-`profiles/report-88e0e6b01a3f-2026-08-21T14-20-37.827Z.json`:
+The unchanged aggregate reports were preserved as ignored artifacts at:
+
+- baseline: `profiles/report-88e0e6b01a3f-2026-08-21T14-34-46.634Z.json`
+- current HEAD: `profiles/report-88e0e6b01a3f-2026-08-21T14-35-51.136Z.json`
+
+Both reports contain three fresh child-process samples, Node `24.19.0`, three
+matching `sampleCompiledArtifactIds`, and successful strict validation.
+
+Raw baseline cold-load measurements (`origin/dev`):
 
 | Sample | Child process | Artifact-load elapsed (ms) | Artifact-load heap delta (bytes) |
 | ---: | ---: | ---: | ---: |
-| 1 | 59992 | 13,441 | 1,107,522,968 |
-| 2 | 60034 | 13,369 | 1,065,253,712 |
-| 3 | 60122 | 12,048 | 1,068,943,728 |
-| **Median** | — | **13,369** | **1,068,943,728** |
+| 1 | 67003 | 12,076 | 1,061,983,872 |
+| 2 | 67050 | 11,922 | 1,115,183,608 |
+| 3 | 67069 | 11,839 | 1,115,042,784 |
+| **Median** | — | **11,922** | **1,115,042,784** |
 
-The aggregate report recorded Node `24.19.0`, successful strictly validated
-requests, and the same compiled artifact identity in all three children.
+Raw current-HEAD cold-load measurements:
+
+| Sample | Child process | Artifact-load elapsed (ms) | Artifact-load heap delta (bytes) |
+| ---: | ---: | ---: | ---: |
+| 1 | 67121 | 12,650 | 1,078,302,256 |
+| 2 | 67200 | 12,351 | 1,046,724,472 |
+| 3 | 67275 | 12,382 | 1,064,955,776 |
+| **Median** | — | **12,382** | **1,064,955,776** |
+
+After-minus-before median delta: **+460 ms** elapsed and
+**−50,087,008 bytes** heap delta. These are independent fresh-process median
+comparisons, not paired child measurements. Artifact-load elapsed time varied
+across the three samples (11,839–12,076 ms before; 12,351–12,650 ms after),
+and heap deltas are GC-dependent; the delta should therefore be read with that
+sample variance in mind.

--- a/docs/profiling/calculation-baseline.md
+++ b/docs/profiling/calculation-baseline.md
@@ -255,3 +255,33 @@ The 2026-08-20 v1 baseline artifacts live in `profiles/` (gitignored):
 Analyze the CPU profile with any DevTools/`node --prof-process`-compatible
 tool. Note that tsx compiles each module to a single line, so function
 frames map to `file.ts:1`; aggregate by function name, not line.
+
+## Issue #91 schema-aware artifact freeze profile (2026-08-21)
+
+Three fresh Node 24.19.0 child processes ran the v2 harness after replacing
+generic artifact deep-freezing with schema-aware traversal. The successful
+command was:
+
+```sh
+NODE_OPTIONS=--conditions=react-server npm exec --yes --package=node@24 -- node --conditions=react-server node_modules/tsx/dist/cli.mjs scripts/profile-scheduled-calculation.ts
+```
+
+The same real artifact was used for every child:
+
+- path: `data/scheduled/mvv-scheduled-artifact.json`
+- `compiledArtifactId`: `88e0e6b01a3f92900c37fd6b2992601b8600551d207e78bd843396ead691512d`
+- payload: `808,821,104` bytes
+- counts: `9,313` station areas and `2,075,789` connections
+
+Raw cold-load measurements from
+`profiles/report-88e0e6b01a3f-2026-08-21T14-20-37.827Z.json`:
+
+| Sample | Child process | Artifact-load elapsed (ms) | Artifact-load heap delta (bytes) |
+| ---: | ---: | ---: | ---: |
+| 1 | 59992 | 13,441 | 1,107,522,968 |
+| 2 | 60034 | 13,369 | 1,065,253,712 |
+| 3 | 60122 | 12,048 | 1,068,943,728 |
+| **Median** | — | **13,369** | **1,068,943,728** |
+
+The aggregate report recorded Node `24.19.0`, successful strictly validated
+requests, and the same compiled artifact identity in all three children.

--- a/lib/domain/scheduled-routing/artifact.ts
+++ b/lib/domain/scheduled-routing/artifact.ts
@@ -18,6 +18,7 @@ import {
   type GtfsFeedFiles,
   type ScheduledArtifactCore,
 } from "./gtfs.ts";
+import { freezeScheduledArtifact } from "./freeze.ts";
 import { parseOffsetInstant } from "./time.ts";
 import type {
   GtfsAcquisitionRecord,
@@ -392,7 +393,7 @@ export function loadScheduledArtifact(
   validateBundleSummary(manifest.summary, core);
   validateRawArchive(parsed, options.rawArchiveBytes);
   validateFreshness(provenance.acquisition, options.now ?? defaultLoaderNow());
-  const frozen = deepFreeze(parsed);
+  const frozen = freezeScheduledArtifact(parsed);
   loadedScheduledArtifacts.set(absolutePath, frozen);
   const heapUsedAfter = process.memoryUsage().heapUsed;
   logInfo(
@@ -926,16 +927,4 @@ function isExactRecordArray(value: unknown, requiredKeys: readonly string[]): va
 
 function sha256Bytes(value: Uint8Array): string {
   return createHash("sha256").update(value).digest("hex");
-}
-
-function deepFreeze<T>(value: T): T {
-  if (value !== null && typeof value === "object" && !Object.isFrozen(value)) {
-    if (Array.isArray(value)) {
-      for (const child of value) deepFreeze(child);
-    } else {
-      for (const child of Object.values(value)) deepFreeze(child);
-    }
-    Object.freeze(value);
-  }
-  return value;
 }

--- a/lib/domain/scheduled-routing/freeze.ts
+++ b/lib/domain/scheduled-routing/freeze.ts
@@ -1,5 +1,62 @@
 import "server-only";
 
+import type { ScheduledRoutingArtifact, ScheduledRoute } from "./models.ts";
+
+/**
+ * Freeze the persisted scheduled artifact by its schema rather than walking
+ * every object property. The explicit branches avoid the Object.values()
+ * allocations of a generic recursive deep-freeze while retaining the
+ * importer's and loader's immutable snapshot contract.
+ */
+export function freezeScheduledArtifact(artifact: ScheduledRoutingArtifact): ScheduledRoutingArtifact {
+  Object.freeze(artifact.searchStartBounds);
+  Object.freeze(artifact.serviceDateRange);
+
+  Object.freeze(artifact.routes);
+  for (const route of artifact.routes) Object.freeze(route);
+
+  Object.freeze(artifact.trips);
+  for (const trip of artifact.trips) Object.freeze(trip);
+
+  Object.freeze(artifact.stationAreas);
+  for (const area of artifact.stationAreas) {
+    Object.freeze(area.coordinate);
+    Object.freeze(area.transferNeighbors);
+    for (const neighbor of area.transferNeighbors) Object.freeze(neighbor);
+    Object.freeze(area);
+  }
+
+  Object.freeze(artifact.calendars);
+  for (const calendar of artifact.calendars) {
+    Object.freeze(calendar.weekdays);
+    Object.freeze(calendar);
+  }
+
+  Object.freeze(artifact.exceptions);
+  for (const exception of artifact.exceptions) Object.freeze(exception);
+
+  Object.freeze(artifact.connections);
+  for (const connection of artifact.connections) {
+    freezeScheduledRoute(connection.line);
+    Object.freeze(connection);
+  }
+
+  const provenance = artifact.provenance;
+  Object.freeze(provenance.files);
+  for (const file of provenance.files) Object.freeze(file);
+  Object.freeze(provenance.acquisition.officialLicense);
+  Object.freeze(provenance.acquisition.officialProvenance);
+  Object.freeze(provenance.acquisition);
+  Object.freeze(provenance);
+
+  Object.freeze(artifact);
+  return artifact;
+}
+
+function freezeScheduledRoute(route: ScheduledRoute): void {
+  Object.freeze(route);
+}
+
 /**
  * Freeze the structural envelope of a value without traversing large arrays.
  *

--- a/lib/domain/scheduled-routing/gtfs.ts
+++ b/lib/domain/scheduled-routing/gtfs.ts
@@ -20,6 +20,7 @@ import type {
   StationAreaMode,
 } from "./models.ts";
 import { TRANSFER_NEIGHBOR_RADIUS_METERS } from "./models.ts";
+import { freezeScheduledArtifact } from "./freeze.ts";
 import { addServiceDays, parseOffsetInstant, serviceDateAnchorEpochSeconds } from "./time.ts";
 import { buildAreaSpatialIndex, findAreasWithinRadius, haversineDistanceMeters } from "./spatial.ts";
 
@@ -216,7 +217,7 @@ export function importGtfsSchedule(
     provenance,
   };
   if (logProgress) logCompilerProgress(`GTFS import complete (feedId=${feedId}, serviceDateRange=${serviceDateRange.firstDate}..${serviceDateRange.lastDate})`);
-  return deepFreeze(artifact);
+  return freezeScheduledArtifact(artifact);
 }
 
 /** Short alias for callers treating the result as an imported snapshot. */
@@ -1027,16 +1028,4 @@ function writeCanonicalJson(writer: CanonicalHashWriter, value: unknown): void {
     return;
   }
   throw new TypeError("Cannot hash an unsupported provenance value.");
-}
-
-function deepFreeze<T>(value: T): T {
-  if (value !== null && typeof value === "object" && !Object.isFrozen(value)) {
-    if (Array.isArray(value)) {
-      for (const child of value) deepFreeze(child);
-    } else {
-      for (const child of Object.values(value)) deepFreeze(child);
-    }
-    Object.freeze(value);
-  }
-  return value;
 }

--- a/test/scheduled-routing-phase2.test.ts
+++ b/test/scheduled-routing-phase2.test.ts
@@ -67,6 +67,13 @@ function compilerFeedFiles(): GtfsFeedFiles {
   };
 }
 
+function freezeCoverageFeedFiles(): GtfsFeedFiles {
+  return {
+    ...compilerFeedFiles(),
+    "calendar_dates.txt": "service_id,date,exception_type\nfixture-service,20260810,2",
+  };
+}
+
 function localeOrderingCompilerFeedFiles(): GtfsFeedFiles {
   return {
     ...compilerFeedFiles(),
@@ -261,6 +268,56 @@ test("scheduled artifact persists as a compact binary bundle and retains immutab
   assert.strictEqual(loadScheduledArtifact(manifestPath, { now: "2026-08-11T12:00:00Z" }), loaded);
   assert.equal(Object.isFrozen(loaded), true);
   assert.equal(Object.isFrozen(loaded.connections), true);
+  await rm(directory, { recursive: true, force: true });
+});
+
+test("schema-aware artifact loading freezes every persisted artifact branch", async () => {
+  const artifact = compileScheduledArtifact({
+    sourceUrl: SCHEDULED_MVV_FEED_URL,
+    rawArchiveBytes: new TextEncoder().encode("schema-aware-freeze-coverage"),
+    feedFiles: freezeCoverageFeedFiles(),
+    retrievedAt: "2026-08-11T10:00:00Z",
+  });
+  const directory = await mkdtemp(join(tmpdir(), "meeet-schema-aware-freeze-"));
+  const manifestPath = join(directory, "scheduled-bundle.json");
+  writeScheduledArtifact(manifestPath, artifact);
+  const loaded = loadScheduledArtifact(manifestPath, { now: "2026-08-11T12:00:00Z" });
+  const assertFrozen = (value: object): void => assert.equal(Object.isFrozen(value), true);
+
+  assertFrozen(loaded);
+  assertFrozen(loaded.searchStartBounds);
+  assertFrozen(loaded.serviceDateRange);
+  assertFrozen(loaded.routes);
+  for (const route of loaded.routes) assertFrozen(route);
+  assertFrozen(loaded.trips);
+  for (const trip of loaded.trips) assertFrozen(trip);
+  assertFrozen(loaded.stationAreas);
+  for (const area of loaded.stationAreas) {
+    assertFrozen(area);
+    assertFrozen(area.coordinate);
+    assertFrozen(area.transferNeighbors);
+    for (const neighbor of area.transferNeighbors) assertFrozen(neighbor);
+  }
+  assertFrozen(loaded.calendars);
+  for (const calendar of loaded.calendars) {
+    assertFrozen(calendar);
+    assertFrozen(calendar.weekdays);
+  }
+  assertFrozen(loaded.exceptions);
+  for (const exception of loaded.exceptions) assertFrozen(exception);
+  assertFrozen(loaded.connections);
+  for (const connection of loaded.connections) {
+    assertFrozen(connection);
+    assertFrozen(connection.line);
+  }
+  assertFrozen(loaded.provenance);
+  assertFrozen(loaded.provenance.files);
+  for (const file of loaded.provenance.files) assertFrozen(file);
+  assertFrozen(loaded.provenance.acquisition);
+  assertFrozen(loaded.provenance.acquisition.officialLicense);
+  assertFrozen(loaded.provenance.acquisition.officialProvenance);
+
+  assert.strictEqual(loadScheduledArtifact(manifestPath, { now: "2026-08-11T12:00:00Z" }), loaded);
   await rm(directory, { recursive: true, force: true });
 });
 

--- a/test/scheduled-routing.test.ts
+++ b/test/scheduled-routing.test.ts
@@ -237,6 +237,36 @@ test("GTFS import validates station areas, IDs, coordinates, columns, and freeze
   assert.notEqual(schedule.provenance.compiledArtifactId, ACQUISITION.rawArchiveSha256);
   assert.equal(Object.isFrozen(schedule), true);
   assert.equal(Object.isFrozen(schedule.connections), true);
+  assert.equal(Object.isFrozen(schedule.searchStartBounds), true);
+  assert.equal(Object.isFrozen(schedule.serviceDateRange), true);
+  assert.equal(Object.isFrozen(schedule.routes), true);
+  for (const route of schedule.routes) assert.equal(Object.isFrozen(route), true);
+  assert.equal(Object.isFrozen(schedule.trips), true);
+  for (const trip of schedule.trips) assert.equal(Object.isFrozen(trip), true);
+  assert.equal(Object.isFrozen(schedule.stationAreas), true);
+  for (const area of schedule.stationAreas) {
+    assert.equal(Object.isFrozen(area), true);
+    assert.equal(Object.isFrozen(area.coordinate), true);
+    assert.equal(Object.isFrozen(area.transferNeighbors), true);
+    for (const neighbor of area.transferNeighbors) assert.equal(Object.isFrozen(neighbor), true);
+  }
+  assert.equal(Object.isFrozen(schedule.calendars), true);
+  for (const calendar of schedule.calendars) {
+    assert.equal(Object.isFrozen(calendar), true);
+    assert.equal(Object.isFrozen(calendar.weekdays), true);
+  }
+  assert.equal(Object.isFrozen(schedule.exceptions), true);
+  for (const exception of schedule.exceptions) assert.equal(Object.isFrozen(exception), true);
+  for (const connection of schedule.connections) {
+    assert.equal(Object.isFrozen(connection), true);
+    assert.equal(Object.isFrozen(connection.line), true);
+  }
+  assert.equal(Object.isFrozen(schedule.provenance), true);
+  assert.equal(Object.isFrozen(schedule.provenance.files), true);
+  for (const file of schedule.provenance.files) assert.equal(Object.isFrozen(file), true);
+  assert.equal(Object.isFrozen(schedule.provenance.acquisition), true);
+  assert.equal(Object.isFrozen(schedule.provenance.acquisition.officialLicense), true);
+  assert.equal(Object.isFrozen(schedule.provenance.acquisition.officialProvenance), true);
   assert.throws(() => Reflect.apply(Array.prototype.push, schedule.connections, [schedule.connections[0]]), TypeError);
 
   const missingColumn = { ...FIXTURE_FILES, "routes.txt": "route_id\nred" };


### PR DESCRIPTION
Closes #91

Replaces generic recursive artifact freezing with a schema-aware traversal while preserving full persisted-artifact immutability. Adds freeze-coverage regression tests and a controlled Node 24 cold-load comparison against dev.