### PR TITLE
fix: harden v3 request admission

### DIFF
--- a/app/api/meeting/calculate/route.ts
+++ b/app/api/meeting/calculate/route.ts
@@ -1,26 +1,34 @@
-import { handleMeetingPost } from "../../../../lib/domain/meeting-api.ts";
+import {
+  handleMeetingPost,
+  providerConfigurationErrorResponse,
+  type ScheduledCalculationAdmissionLike,
+} from "../../../../lib/domain/meeting-api.ts";
 import { ProviderConfigurationError } from "../../../../lib/providers/config.ts";
 import { createMeetingProviders } from "../../../../lib/providers/factory.ts";
+import type { MeetingProviders } from "../../../../lib/domain/providers.ts";
 
 export const maxDuration = 90;
 
-export async function POST(request: Request): Promise<Response> {
-  try {
-    // The factory is deliberately deferred until handleMeetingPost has acquired
-    // the process-local slot. Artifact loading must not happen before admission.
-    return await handleMeetingPost(request, () => createMeetingProviders());
-  } catch (error) {
-    if (error instanceof ProviderConfigurationError) {
-      return Response.json(
-        {
-          error: {
-            code: "PROVIDER_CONFIGURATION_INVALID",
-            message: "Server provider configuration is invalid.",
-          },
-        },
-        { status: 503 },
-      );
-    }
-    throw error;
-  }
+export interface MeetingCalculateRouteDependencies {
+  readonly createProviders?: () => MeetingProviders;
+  readonly admission?: ScheduledCalculationAdmissionLike;
 }
+
+export function createMeetingCalculatePost(
+  dependencies: MeetingCalculateRouteDependencies = {},
+): (request: Request) => Promise<Response> {
+  const providersSource = dependencies.createProviders ?? (() => createMeetingProviders());
+  const options = dependencies.admission === undefined ? {} : { admission: dependencies.admission };
+  return async function POST(request: Request): Promise<Response> {
+    try {
+      // The factory is deliberately deferred until handleMeetingPost has acquired
+      // the process-local slot. Artifact loading must not happen before admission.
+      return await handleMeetingPost(request, providersSource, options);
+    } catch (error) {
+      if (error instanceof ProviderConfigurationError) return providerConfigurationErrorResponse();
+      throw error;
+    }
+  };
+}
+
+export const POST = createMeetingCalculatePost();

--- a/app/api/meeting/calculate/stream/route.ts
+++ b/app/api/meeting/calculate/stream/route.ts
@@ -1,28 +1,36 @@
-import { handleMeetingStreamPost } from "../../../../../lib/domain/meeting-api.ts";
+import {
+  handleMeetingStreamPost,
+  providerConfigurationErrorResponse,
+  type ScheduledCalculationAdmissionLike,
+} from "../../../../../lib/domain/meeting-api.ts";
 import { ProviderConfigurationError } from "../../../../../lib/providers/config.ts";
 import { createMeetingProviders } from "../../../../../lib/providers/factory.ts";
+import type { MeetingProviders } from "../../../../../lib/domain/providers.ts";
 
 export const maxDuration = 90;
 
-export async function POST(request: Request): Promise<Response> {
-  try {
-    // The factory is deliberately deferred until handleMeetingStreamPost has
-    // acquired the process-local slot. Artifact loading must not happen before
-    // admission, and the stream must never start for invalid input or refused
-    // admission.
-    return await handleMeetingStreamPost(request, () => createMeetingProviders());
-  } catch (error) {
-    if (error instanceof ProviderConfigurationError) {
-      return Response.json(
-        {
-          error: {
-            code: "PROVIDER_CONFIGURATION_INVALID",
-            message: "Server provider configuration is invalid.",
-          },
-        },
-        { status: 503 },
-      );
-    }
-    throw error;
-  }
+export interface MeetingStreamRouteDependencies {
+  readonly createProviders?: () => MeetingProviders;
+  readonly admission?: ScheduledCalculationAdmissionLike;
 }
+
+export function createMeetingStreamPost(
+  dependencies: MeetingStreamRouteDependencies = {},
+): (request: Request) => Promise<Response> {
+  const providersSource = dependencies.createProviders ?? (() => createMeetingProviders());
+  const options = dependencies.admission === undefined ? {} : { admission: dependencies.admission };
+  return async function POST(request: Request): Promise<Response> {
+    try {
+      // The factory is deliberately deferred until handleMeetingStreamPost has
+      // acquired the process-local slot. Artifact loading must not happen before
+      // admission, and the stream must never start for invalid input or refused
+      // admission.
+      return await handleMeetingStreamPost(request, providersSource, options);
+    } catch (error) {
+      if (error instanceof ProviderConfigurationError) return providerConfigurationErrorResponse();
+      throw error;
+    }
+  };
+}
+
+export const POST = createMeetingStreamPost();

--- a/app/api/meeting/station-areas/[stationAreaId]/details/route.ts
+++ b/app/api/meeting/station-areas/[stationAreaId]/details/route.ts
@@ -1,28 +1,45 @@
-import { handleStationAreaDetailsPost } from "../../../../../../lib/domain/meeting-api.ts";
+import {
+  handleStationAreaDetailsPost,
+  providerConfigurationErrorResponse,
+  type HandleMeetingPostOptions,
+  type ScheduledCalculationAdmissionLike,
+} from "../../../../../../lib/domain/meeting-api.ts";
 import { ProviderConfigurationError } from "../../../../../../lib/providers/config.ts";
 import { createMeetingProviders } from "../../../../../../lib/providers/factory.ts";
+import type { MeetingProviders } from "../../../../../../lib/domain/providers.ts";
+import type { StationAreaCalculationBasisCache } from "../../../../../../lib/domain/station-area-details-cache.ts";
 
 export const maxDuration = 90;
 
-export async function POST(
+export interface StationAreaDetailsRouteDependencies {
+  readonly createProviders?: () => MeetingProviders;
+  readonly admission?: ScheduledCalculationAdmissionLike;
+  readonly basisCache?: StationAreaCalculationBasisCache;
+}
+
+export function createStationAreaDetailsPost(
+  dependencies: StationAreaDetailsRouteDependencies = {},
+): (
   request: Request,
   context: { params: Promise<{ stationAreaId: string }> },
-): Promise<Response> {
-  try {
-    const { stationAreaId } = await context.params;
-    return await handleStationAreaDetailsPost(request, stationAreaId, () => createMeetingProviders());
-  } catch (error) {
-    if (error instanceof ProviderConfigurationError) {
-      return Response.json(
-        {
-          error: {
-            code: "PROVIDER_CONFIGURATION_INVALID",
-            message: "Server provider configuration is invalid.",
-          },
-        },
-        { status: 503 },
-      );
+) => Promise<Response> {
+  const providersSource = dependencies.createProviders ?? (() => createMeetingProviders());
+  const options: HandleMeetingPostOptions = {
+    ...(dependencies.admission === undefined ? {} : { admission: dependencies.admission }),
+    ...(dependencies.basisCache === undefined ? {} : { basisCache: dependencies.basisCache }),
+  };
+  return async function POST(
+    request: Request,
+    context: { params: Promise<{ stationAreaId: string }> },
+  ): Promise<Response> {
+    try {
+      const { stationAreaId } = await context.params;
+      return await handleStationAreaDetailsPost(request, stationAreaId, providersSource, options);
+    } catch (error) {
+      if (error instanceof ProviderConfigurationError) return providerConfigurationErrorResponse();
+      throw error;
     }
-    throw error;
-  }
+  };
 }
+
+export const POST = createStationAreaDetailsPost();

--- a/lib/domain/meeting-api.ts
+++ b/lib/domain/meeting-api.ts
@@ -272,7 +272,7 @@ export async function handleMeetingStreamPost(
       if (error instanceof ProviderConfigurationError) throw error;
       // Generic factory failures retain the established stream contract: the
       // response starts as SSE and reports one safe terminal failure event.
-      providerFactoryFailure = { error };
+      providerFactoryFailure = { error: normalizeProviderFactoryFailure() };
     }
     acquired.deadline.check();
   } catch (error) {
@@ -617,6 +617,10 @@ function isTooLargeContentLength(value: string): boolean {
 
 function isCalculationReferenceSyntaxValid(value: string): boolean {
   return value.length <= 256 && /^[A-Za-z0-9._~-]+$/.test(value);
+}
+
+function normalizeProviderFactoryFailure(): Error {
+  return new Error("The scheduled meeting provider factory failed.");
 }
 
 type ParsedMeetingRequestResult =

--- a/lib/domain/meeting-api.ts
+++ b/lib/domain/meeting-api.ts
@@ -17,7 +17,6 @@ import {
   scheduledCalculationAdmission,
   SCHEDULED_CALCULATION_CONCURRENCY,
   SCHEDULED_CALCULATION_DEADLINE_MS,
-  type ScheduledCalculationAdmission,
   type ScheduledDeadlineOptions,
   type ScheduledCalculationDeadline,
 } from "./scheduled-admission.ts";
@@ -62,6 +61,7 @@ export type MeetingApiErrorCode =
   | "INVALID_REQUEST"
   | "REQUEST_TOO_LARGE"
   | "TEMPORARILY_UNAVAILABLE"
+  | "PROVIDER_CONFIGURATION_INVALID"
   | "PROVIDER_NOT_CONFIGURED"
   | "PROVIDER_UNAVAILABLE"
   | "CALCULATION_FAILED"
@@ -81,8 +81,12 @@ export interface MeetingApiErrorResponse {
 
 export type MeetingProvidersSource = MeetingProviders | (() => MeetingProviders);
 
+export interface ScheduledCalculationAdmissionLike {
+  tryAcquire(): (() => void) | null;
+}
+
 export interface HandleMeetingPostOptions {
-  readonly admission?: ScheduledCalculationAdmission;
+  readonly admission?: ScheduledCalculationAdmissionLike;
   readonly deadline?: ScheduledDeadlineOptions;
   /** Flat aliases keep the server test seam convenient without changing policy. */
   readonly deadlineMs?: number;
@@ -144,34 +148,8 @@ export async function acquireScheduledMeetingCalculation(
   options: HandleMeetingPostOptions = {},
 ): Promise<AcquireScheduledMeetingCalculationResult> {
   const startedAt = Date.now();
-  const declaredLength = request.headers.get("content-length");
-  if (declaredLength && isTooLargeContentLength(declaredLength)) {
-    return { kind: "error", ...errorOutcome(413, "REQUEST_TOO_LARGE", `Request body must not exceed ${MAX_MEETING_REQUEST_BODY_BYTES} bytes.`) };
-  }
-
-  let bodyText: string;
-  try {
-    bodyText = await request.text();
-  } catch {
-    return { kind: "error", ...errorOutcome(400, "MALFORMED_JSON", "Request body could not be read as JSON.") };
-  }
-
-  if (new TextEncoder().encode(bodyText).byteLength > MAX_MEETING_REQUEST_BODY_BYTES) {
-    return { kind: "error", ...errorOutcome(413, "REQUEST_TOO_LARGE", `Request body must not exceed ${MAX_MEETING_REQUEST_BODY_BYTES} bytes.`) };
-  }
-
-  let body: unknown;
-  try {
-    body = JSON.parse(bodyText) as unknown;
-  } catch {
-    return { kind: "error", ...errorOutcome(400, "MALFORMED_JSON", "Request body must contain valid JSON.") };
-  }
-
-  const parsedScheduled = parseScheduledMeetingRequest(body);
-  if (!parsedScheduled.success) {
-    return { kind: "error", ...errorOutcome(400, "INVALID_REQUEST", "Request body must use the meeet-meeting/v3 scheduled contract.", parsedScheduled.issues) };
-  }
-  logInfo(`calculation: request accepted (contract=${parsedScheduled.data.contractVersion}, participants=${parsedScheduled.data.participants.length}, tolerance=${parsedScheduled.data.tolerancePercent}%, changeTimePreset=${parsedScheduled.data.changeTimePreset}, searchStartAt=${parsedScheduled.data.searchStartAt})`);
+  const parsedScheduled = await parseMeetingRequestBody(request);
+  if (parsedScheduled.kind === "error") return parsedScheduled;
   const release = (options.admission ?? scheduledCalculationAdmission).tryAcquire();
   if (release === null) {
     logError(`calculation: rejected (concurrency limit reached, elapsed=${Date.now() - startedAt}ms)`);
@@ -206,7 +184,7 @@ export async function acquireScheduledMeetingCalculation(
   }
   return {
     kind: "acquired",
-    parsed: parsedScheduled.data,
+    parsed: parsedScheduled.parsed,
     release,
     deadline,
     basisCache: options.basisCache ?? stationAreaCalculationBasisCache,
@@ -284,6 +262,30 @@ export async function handleMeetingStreamPost(
   if (acquired.kind === "error") {
     return jsonError(acquired.status, acquired.code, acquired.message, acquired.issues);
   }
+  let providers: MeetingProviders | undefined;
+  let providerFactoryFailure: { readonly error: unknown } | null = null;
+  try {
+    acquired.deadline.check();
+    try {
+      providers = typeof providersSource === "function" ? providersSource() : providersSource;
+    } catch (error) {
+      if (error instanceof ProviderConfigurationError) throw error;
+      // Generic factory failures retain the established stream contract: the
+      // response starts as SSE and reports one safe terminal failure event.
+      providerFactoryFailure = { error };
+    }
+    acquired.deadline.check();
+  } catch (error) {
+    acquired.deadline.dispose();
+    acquired.release();
+    if (error instanceof ProviderConfigurationError) throw error;
+    if (acquired.deadline.isExpired()) {
+      return jsonError(503, "TEMPORARILY_UNAVAILABLE", "The scheduled meeting calculation exceeded its 90-second deadline. Please try again shortly.");
+    }
+    const outcome = scheduledErrorOutcome(error);
+    return jsonError(outcome.status, outcome.code, outcome.message, outcome.issues);
+  }
+  const resolvedProviders = providers;
   logInfo("calculation: stream started");
   const heartbeatMs = options.heartbeatMs ?? MEETING_STREAM_DEFAULT_HEARTBEAT_MS;
   const encoder = new TextEncoder();
@@ -339,7 +341,15 @@ export async function handleMeetingStreamPost(
       };
       void (async () => {
         try {
-          const run = await runScheduledMeetingCalculation(acquired, providersSource, hooks);
+          const run = providerFactoryFailure === null
+            ? resolvedProviders === undefined
+              ? await runScheduledMeetingCalculation(acquired, () => {
+                throw new Error("The scheduled meeting provider factory returned no providers.");
+              }, hooks)
+              : await runScheduledMeetingCalculation(acquired, resolvedProviders, hooks)
+            : await runScheduledMeetingCalculation(acquired, () => {
+              throw providerFactoryFailure.error;
+            }, hooks);
           if (run.kind === "error") {
             await write(`event: error\ndata: ${JSON.stringify({ code: run.code, message: run.message })}\n\n`);
           } else {
@@ -406,34 +416,20 @@ async function handleStationAreaDetailsPostInner(
   providersSource: MeetingProvidersSource,
   options: HandleMeetingPostOptions = {},
 ): Promise<Response> {
-  if (stationAreaId.trim() === "") return jsonError(400, "INVALID_REQUEST", "stationAreaId must be non-empty.");
-  const declaredLength = request.headers.get("content-length");
-  if (declaredLength && isTooLargeContentLength(declaredLength)) return jsonError(413, "REQUEST_TOO_LARGE", `Request body must not exceed ${MAX_MEETING_REQUEST_BODY_BYTES} bytes.`);
-  let bodyText: string;
-  try {
-    bodyText = await request.text();
-  } catch {
-    return jsonError(400, "MALFORMED_JSON", "Request body could not be read as JSON.");
-  }
-  if (new TextEncoder().encode(bodyText).byteLength > MAX_MEETING_REQUEST_BODY_BYTES) return jsonError(413, "REQUEST_TOO_LARGE", `Request body must not exceed ${MAX_MEETING_REQUEST_BODY_BYTES} bytes.`);
-  let body: unknown;
-  try {
-    body = JSON.parse(bodyText) as unknown;
-  } catch {
-    return jsonError(400, "MALFORMED_JSON", "Request body must contain valid JSON.");
-  }
-  const parsedScheduled = parseScheduledMeetingRequest(body);
-  if (!parsedScheduled.success) return jsonError(400, "INVALID_REQUEST", "Request body must use the meeet-meeting/v3 scheduled contract.", parsedScheduled.issues);
+  if (typeof stationAreaId !== "string" || stationAreaId.trim() === "") return jsonError(400, "INVALID_REQUEST", "stationAreaId must be non-empty.");
+  const parsedScheduled = await parseMeetingRequestBody(request, { logAccepted: false });
+  if (parsedScheduled.kind === "error") return jsonError(parsedScheduled.status, parsedScheduled.code, parsedScheduled.message, parsedScheduled.issues);
   const reference = request.headers.get(STATION_AREA_CALCULATION_REF_HEADER);
   if (reference === null || reference.trim() === "") return jsonError(400, "INVALID_CALCULATION_REF", `The ${STATION_AREA_CALCULATION_REF_HEADER} header is required.`);
+  if (!isCalculationReferenceSyntaxValid(reference)) return jsonError(400, "INVALID_CALCULATION_REF", `The ${STATION_AREA_CALCULATION_REF_HEADER} header is malformed.`);
   const basisCache = options.basisCache ?? stationAreaCalculationBasisCache;
   const basis = basisCache.get(reference);
   if (basis === undefined) return jsonError(410, "CALCULATION_REF_EXPIRED", "The calculation reference is missing or has expired. Recalculate the meeting surface.");
-  if (!sameScheduledRequest(basis.canonicalRequest, parsedScheduled.data)) return jsonError(409, "CALCULATION_REF_MISMATCH", "The calculation reference does not match the supplied meeet-meeting/v3 request.");
+  if (!sameScheduledRequest(basis.canonicalRequest, parsedScheduled.parsed)) return jsonError(409, "CALCULATION_REF_MISMATCH", "The calculation reference does not match the supplied meeet-meeting/v3 request.");
   const marker = basis.stationAreas.find((candidate) => candidate.stationAreaId === stationAreaId);
   if (marker === undefined) return jsonError(404, "STATION_AREA_NOT_FOUND", "The requested station area is not in the cached calculation surface.");
   if (basis.status === "no-result" || marker.classification === "unclassified") {
-    return unavailableStationAreaDetailsResponse(parsedScheduled.data, basis, marker);
+    return unavailableStationAreaDetailsResponse(parsedScheduled.parsed, basis, marker);
   }
 
   const release = (options.admission ?? scheduledCalculationAdmission).tryAcquire();
@@ -456,10 +452,10 @@ async function handleStationAreaDetailsPostInner(
       return jsonError(409, "CALCULATION_REF_MISMATCH", "The calculation reference belongs to a different scheduled timetable artifact.");
     }
     const participants: [StationAreaDetailParticipantDto, StationAreaDetailParticipantDto] = [
-      detailParticipant("red", 0, parsedScheduled.data.participants[0], marker, basis, artifact, parsedScheduled.data.searchStartAt),
-      detailParticipant("blue", 1, parsedScheduled.data.participants[1], marker, basis, artifact, parsedScheduled.data.searchStartAt),
+      detailParticipant("red", 0, parsedScheduled.parsed.participants[0], marker, basis, artifact, parsedScheduled.parsed.searchStartAt),
+      detailParticipant("blue", 1, parsedScheduled.parsed.participants[1], marker, basis, artifact, parsedScheduled.parsed.searchStartAt),
     ];
-    const detailBasis = makeDetailBasis(parsedScheduled.data, basis);
+    const detailBasis = makeDetailBasis(parsedScheduled.parsed, basis);
     const detail: StationAreaDetailsResponseDto = deepFreeze({
       contractVersion: STATION_AREA_DETAILS_CONTRACT_VERSION,
       status: basis.status,
@@ -469,7 +465,7 @@ async function handleStationAreaDetailsPostInner(
       basis: detailBasis,
     });
     deadline.check();
-    const validation = validateStationAreaDetailsResponse(detail, { request: parsedScheduled.data, selectedMarker: marker, artifactIdentity: basis.artifactIdentity });
+    const validation = validateStationAreaDetailsResponse(detail, { request: parsedScheduled.parsed, selectedMarker: marker, artifactIdentity: basis.artifactIdentity });
     if (!validation.success) return jsonError(500, "DETAIL_FAILED", "The station-area detail response failed strict validation.");
     return Response.json(detail, { status: 200 });
   } catch (error) {
@@ -617,6 +613,55 @@ function withDeadlineCheckedAccess(
 
 function isTooLargeContentLength(value: string): boolean {
   return /^\d+$/.test(value) && Number(value) > MAX_MEETING_REQUEST_BODY_BYTES;
+}
+
+function isCalculationReferenceSyntaxValid(value: string): boolean {
+  return value.length <= 256 && /^[A-Za-z0-9._~-]+$/.test(value);
+}
+
+type ParsedMeetingRequestResult =
+  | { readonly kind: "parsed"; readonly parsed: ScheduledMeetingRequest }
+  | ({ readonly kind: "error" } & ScheduledCalculationErrorOutcome);
+
+async function parseMeetingRequestBody(
+  request: Request,
+  options: { readonly logAccepted?: boolean } = {},
+): Promise<ParsedMeetingRequestResult> {
+  const declaredLength = request.headers.get("content-length");
+  if (declaredLength && isTooLargeContentLength(declaredLength)) {
+    return { kind: "error", ...errorOutcome(413, "REQUEST_TOO_LARGE", `Request body must not exceed ${MAX_MEETING_REQUEST_BODY_BYTES} bytes.`) };
+  }
+
+  let bodyText: string;
+  try {
+    bodyText = await request.text();
+  } catch {
+    return { kind: "error", ...errorOutcome(400, "MALFORMED_JSON", "Request body could not be read as JSON.") };
+  }
+
+  if (new TextEncoder().encode(bodyText).byteLength > MAX_MEETING_REQUEST_BODY_BYTES) {
+    return { kind: "error", ...errorOutcome(413, "REQUEST_TOO_LARGE", `Request body must not exceed ${MAX_MEETING_REQUEST_BODY_BYTES} bytes.`) };
+  }
+
+  let body: unknown;
+  try {
+    body = JSON.parse(bodyText) as unknown;
+  } catch {
+    return { kind: "error", ...errorOutcome(400, "MALFORMED_JSON", "Request body must contain valid JSON.") };
+  }
+
+  const parsedScheduled = parseScheduledMeetingRequest(body);
+  if (!parsedScheduled.success) {
+    return { kind: "error", ...errorOutcome(400, "INVALID_REQUEST", "Request body must use the meeet-meeting/v3 scheduled contract.", parsedScheduled.issues) };
+  }
+  if (options.logAccepted !== false) {
+    logInfo(`calculation: request accepted (contract=${parsedScheduled.data.contractVersion}, participants=${parsedScheduled.data.participants.length}, tolerance=${parsedScheduled.data.tolerancePercent}%, changeTimePreset=${parsedScheduled.data.changeTimePreset}, searchStartAt=${parsedScheduled.data.searchStartAt})`);
+  }
+  return { kind: "parsed", parsed: parsedScheduled.data };
+}
+
+export function providerConfigurationErrorResponse(): Response {
+  return jsonError(503, "PROVIDER_CONFIGURATION_INVALID", "Server provider configuration is invalid.");
 }
 
 function jsonError(

--- a/test/meeting-admission.test.ts
+++ b/test/meeting-admission.test.ts
@@ -1,0 +1,314 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import { createMeetingCalculatePost } from "../app/api/meeting/calculate/route.ts";
+import { createMeetingStreamPost } from "../app/api/meeting/calculate/stream/route.ts";
+import { createStationAreaDetailsPost } from "../app/api/meeting/station-areas/[stationAreaId]/details/route.ts";
+import {
+  handleMeetingPost,
+  MAX_MEETING_REQUEST_BODY_BYTES,
+} from "../lib/domain/meeting-api.ts";
+import { ScheduledCalculationAdmission } from "../lib/domain/scheduled-admission.ts";
+import { InMemoryStationAreaCalculationBasisCache } from "../lib/domain/station-area-details-cache.ts";
+import { FIXTURE_SCHEDULED_ACCESS_PROVIDER, FIXTURE_SCHEDULED_ARTIFACT } from "../lib/fixtures/scheduled-routing.ts";
+import { ProviderConfigurationError } from "../lib/providers/config.ts";
+import type { MeetingProviders } from "../lib/domain/providers.ts";
+
+const REQUEST = {
+  contractVersion: "meeet-meeting/v3",
+  participants: [
+    { id: "red", origin: { label: "Red", latitude: 48.1374, longitude: 11.5755 }, mode: "transit" },
+    { id: "blue", origin: { label: "Blue", latitude: 48.1400, longitude: 11.5700 }, mode: "transit" },
+  ],
+  tolerancePercent: 10,
+  changeTimePreset: "medium",
+  searchStartAt: "2026-08-11T08:05:00+02:00",
+} as const;
+
+const PROVIDERS: MeetingProviders = {
+  scheduledArtifact: FIXTURE_SCHEDULED_ARTIFACT,
+  scheduledAccess: FIXTURE_SCHEDULED_ACCESS_PROVIDER,
+};
+
+const CALCULATE_URL = "https://meeet.test/api/meeting/calculate";
+const STREAM_URL = "https://meeet.test/api/meeting/calculate/stream";
+const DETAILS_URL = "https://meeet.test/api/meeting/station-areas/fixture-c/details";
+
+class CountingAdmission extends ScheduledCalculationAdmission {
+  calls = 0;
+
+  override tryAcquire(): (() => void) | null {
+    this.calls += 1;
+    return super.tryAcquire();
+  }
+}
+
+class UnreadableRequest extends Request {
+  override async text(): Promise<string> {
+    throw new Error("body stream unavailable: secret transport detail");
+  }
+}
+
+function request(url: string, body: string, headers: Record<string, string> = {}): Request {
+  return new Request(url, {
+    method: "POST",
+    body,
+    headers,
+  });
+}
+
+function validBody(): string {
+  return JSON.stringify(REQUEST);
+}
+
+const bodyCases: Array<{
+  name: string;
+  makeRequest: (url: string) => Request;
+  status: number;
+  code: string;
+}> = [
+  {
+    name: "declared oversized body",
+    makeRequest: (url) => request(url, validBody(), { "content-length": String(MAX_MEETING_REQUEST_BODY_BYTES + 1) }),
+    status: 413,
+    code: "REQUEST_TOO_LARGE",
+  },
+  {
+    name: "actual oversized body",
+    makeRequest: (url) => request(url, "x".repeat(MAX_MEETING_REQUEST_BODY_BYTES + 1)),
+    status: 413,
+    code: "REQUEST_TOO_LARGE",
+  },
+  {
+    name: "unreadable body",
+    makeRequest: (url) => new UnreadableRequest(url, { method: "POST", body: validBody() }),
+    status: 400,
+    code: "MALFORMED_JSON",
+  },
+  {
+    name: "malformed JSON body",
+    makeRequest: (url) => request(url, "{"),
+    status: 400,
+    code: "MALFORMED_JSON",
+  },
+  {
+    name: "blank body",
+    makeRequest: (url) => request(url, " \t\n "),
+    status: 400,
+    code: "MALFORMED_JSON",
+  },
+  {
+    name: "retired request contract",
+    makeRequest: (url) => request(url, JSON.stringify({ participants: REQUEST.participants, arrivalAt: REQUEST.searchStartAt, tolerancePercent: 10 })),
+    status: 400,
+    code: "INVALID_REQUEST",
+  },
+  {
+    name: "unknown v3 request field",
+    makeRequest: (url) => request(url, JSON.stringify({ ...REQUEST, unexpected: true })),
+    status: 400,
+    code: "INVALID_REQUEST",
+  },
+];
+
+test("calculate adapter rejects request bodies before provider or admission work", async () => {
+  for (const testCase of bodyCases) {
+    const admission = new CountingAdmission();
+    let factoryCalls = 0;
+    const post = createMeetingCalculatePost({
+      admission,
+      createProviders: () => {
+        factoryCalls += 1;
+        return PROVIDERS;
+      },
+    });
+    const response = await post(testCase.makeRequest(CALCULATE_URL));
+    assert.equal(response.status, testCase.status, testCase.name);
+    assert.equal((await response.json()).error.code, testCase.code, testCase.name);
+    assert.equal(factoryCalls, 0, `${testCase.name}: provider factory must not run`);
+    assert.equal(admission.calls, 0, `${testCase.name}: admission must not run`);
+  }
+});
+
+test("stream adapter rejects request bodies as JSON before SSE commencement or work", async () => {
+  for (const testCase of bodyCases) {
+    const admission = new CountingAdmission();
+    let factoryCalls = 0;
+    const post = createMeetingStreamPost({
+      admission,
+      createProviders: () => {
+        factoryCalls += 1;
+        return PROVIDERS;
+      },
+    });
+    const response = await post(testCase.makeRequest(STREAM_URL));
+    assert.equal(response.status, testCase.status, testCase.name);
+    assert.equal(response.headers.get("content-type"), "application/json", testCase.name);
+    assert.equal((await response.json()).error.code, testCase.code, testCase.name);
+    assert.equal(factoryCalls, 0, `${testCase.name}: provider factory must not run`);
+    assert.equal(admission.calls, 0, `${testCase.name}: admission must not run`);
+  }
+});
+
+const detailInputCases: Array<{
+  name: string;
+  stationAreaId: string;
+  makeRequest: () => Request;
+  status: number;
+  code: string;
+}> = [
+  {
+    name: "declared oversized body",
+    stationAreaId: "fixture-c",
+    makeRequest: () => request(DETAILS_URL, validBody(), { "Meeet-Calculation-Ref": "missing", "content-length": String(MAX_MEETING_REQUEST_BODY_BYTES + 1) }),
+    status: 413,
+    code: "REQUEST_TOO_LARGE",
+  },
+  {
+    name: "actual oversized body",
+    stationAreaId: "fixture-c",
+    makeRequest: () => request(DETAILS_URL, "x".repeat(MAX_MEETING_REQUEST_BODY_BYTES + 1), { "Meeet-Calculation-Ref": "missing" }),
+    status: 413,
+    code: "REQUEST_TOO_LARGE",
+  },
+  {
+    name: "unreadable body",
+    stationAreaId: "fixture-c",
+    makeRequest: () => new UnreadableRequest(DETAILS_URL, { method: "POST", body: validBody(), headers: { "Meeet-Calculation-Ref": "missing" } }),
+    status: 400,
+    code: "MALFORMED_JSON",
+  },
+  {
+    name: "malformed JSON body",
+    stationAreaId: "fixture-c",
+    makeRequest: () => request(DETAILS_URL, "{", { "Meeet-Calculation-Ref": "missing" }),
+    status: 400,
+    code: "MALFORMED_JSON",
+  },
+  {
+    name: "missing calculation reference",
+    stationAreaId: "fixture-c",
+    makeRequest: () => request(DETAILS_URL, validBody()),
+    status: 400,
+    code: "INVALID_CALCULATION_REF",
+  },
+  {
+    name: "blank calculation reference",
+    stationAreaId: "fixture-c",
+    makeRequest: () => request(DETAILS_URL, validBody(), { "Meeet-Calculation-Ref": " \t" }),
+    status: 400,
+    code: "INVALID_CALCULATION_REF",
+  },
+  {
+    name: "malformed calculation reference",
+    stationAreaId: "fixture-c",
+    makeRequest: () => request(DETAILS_URL, validBody(), { "Meeet-Calculation-Ref": "not a reference" }),
+    status: 400,
+    code: "INVALID_CALCULATION_REF",
+  },
+  {
+    name: "unknown calculation reference",
+    stationAreaId: "fixture-c",
+    makeRequest: () => request(DETAILS_URL, validBody(), { "Meeet-Calculation-Ref": "missing" }),
+    status: 410,
+    code: "CALCULATION_REF_EXPIRED",
+  },
+  {
+    name: "invalid station area input",
+    stationAreaId: " ",
+    makeRequest: () => request(DETAILS_URL, validBody()),
+    status: 400,
+    code: "INVALID_REQUEST",
+  },
+  {
+    name: "missing station area input",
+    stationAreaId: undefined as unknown as string,
+    makeRequest: () => request(DETAILS_URL, validBody()),
+    status: 400,
+    code: "INVALID_REQUEST",
+  },
+];
+
+test("station-area details rejects invalid inputs before provider or admission work", async () => {
+  for (const testCase of detailInputCases) {
+    const admission = new CountingAdmission();
+    let factoryCalls = 0;
+    const post = createStationAreaDetailsPost({
+      admission,
+      createProviders: () => {
+        factoryCalls += 1;
+        return PROVIDERS;
+      },
+    });
+    const response = await post(testCase.makeRequest(), { params: Promise.resolve({ stationAreaId: testCase.stationAreaId }) });
+    assert.equal(response.status, testCase.status, testCase.name);
+    assert.equal((await response.json()).error.code, testCase.code, testCase.name);
+    assert.equal(factoryCalls, 0, `${testCase.name}: provider factory must not run`);
+    assert.equal(admission.calls, 0, `${testCase.name}: admission must not run`);
+  }
+});
+
+test("station-area details rejects an unknown nonblank station area before provider or admission work", async () => {
+  const cache = new InMemoryStationAreaCalculationBasisCache({ referenceFactory: () => "admission-details-reference" });
+  const calculated = await handleMeetingPost(request(CALCULATE_URL, validBody()), PROVIDERS, {
+    basisCache: cache,
+    admission: new ScheduledCalculationAdmission(),
+  });
+  assert.equal(calculated.status, 200);
+  const reference = calculated.headers.get("Meeet-Calculation-Ref");
+  assert.equal(reference, "admission-details-reference");
+
+  const admission = new CountingAdmission();
+  let factoryCalls = 0;
+  const post = createStationAreaDetailsPost({
+    admission,
+    basisCache: cache,
+    createProviders: () => {
+      factoryCalls += 1;
+      return PROVIDERS;
+    },
+  });
+  const response = await post(
+    request(DETAILS_URL, validBody(), { "Meeet-Calculation-Ref": reference! }),
+    { params: Promise.resolve({ stationAreaId: "unknown-station-area" }) },
+  );
+  assert.equal(response.status, 404);
+  assert.equal((await response.json()).error.code, "STATION_AREA_NOT_FOUND");
+  assert.equal(factoryCalls, 0);
+  assert.equal(admission.calls, 0);
+});
+
+test("all public adapters sanitize provider configuration failures", async () => {
+  const fail = () => {
+    throw new ProviderConfigurationError("secret internal configuration detail");
+  };
+
+  const calculateAdmission = new CountingAdmission();
+  const calculate = await createMeetingCalculatePost({ createProviders: fail, admission: calculateAdmission })(request(CALCULATE_URL, validBody()));
+  const streamAdmission = new CountingAdmission();
+  const stream = await createMeetingStreamPost({ createProviders: fail, admission: streamAdmission })(request(STREAM_URL, validBody()));
+
+  const cache = new InMemoryStationAreaCalculationBasisCache({ referenceFactory: () => "configuration-ref" });
+  const calculation = await handleMeetingPost(request(CALCULATE_URL, validBody()), PROVIDERS, { basisCache: cache, admission: new ScheduledCalculationAdmission() });
+  assert.equal(calculation.status, 200);
+  const detailsAdmission = new CountingAdmission();
+  const details = await createStationAreaDetailsPost({ createProviders: fail, basisCache: cache, admission: detailsAdmission })(request(DETAILS_URL, validBody(), { "Meeet-Calculation-Ref": "configuration-ref" }), { params: Promise.resolve({ stationAreaId: "fixture-c" }) });
+
+  for (const response of [calculate, stream, details]) {
+    assert.equal(response.status, 503);
+    assert.equal(response.headers.get("content-type"), "application/json");
+    const body = await response.json();
+    assert.deepEqual(body, {
+      error: {
+        code: "PROVIDER_CONFIGURATION_INVALID",
+        message: "Server provider configuration is invalid.",
+      },
+    });
+    assert.equal(JSON.stringify(body).includes("secret internal"), false);
+  }
+  for (const admission of [calculateAdmission, streamAdmission, detailsAdmission]) {
+    const release = admission.tryAcquire();
+    assert.ok(release, "provider configuration failure must release admission");
+    release();
+  }
+});

--- a/test/meeting-stream.test.ts
+++ b/test/meeting-stream.test.ts
@@ -291,17 +291,23 @@ test("heartbeat comments keep the stream alive during slow access", async () => 
   assert.ok(body.includes(": heartbeat"));
 });
 
-test("provider factory throws a terminal error event with a safe message", async () => {
+test("provider factory throws one safe terminal SSE error event", async () => {
+  const admission = new ScheduledCalculationAdmission();
   const response = await handleMeetingStreamPost(streamRequest(), () => {
     throw new Error("secret internal detail: token=abc123");
-  }, { admission: new ScheduledCalculationAdmission() });
-  const body = await response.text();
-  const frames = parseSseFrames(body);
-  const errorFrame = frames.find((frame) => frame.event === "error");
-  assert.ok(errorFrame?.data);
-  const error = JSON.parse(errorFrame.data);
+  }, { admission });
+  assert.equal(response.status, 200);
+  assert.equal(response.headers.get("content-type"), "text/event-stream");
+  const frames = parseSseFrames(await response.text());
+  const terminal = frames.filter((frame) => frame.event === "result" || frame.event === "error");
+  assert.equal(terminal.length, 1);
+  assert.equal(terminal[0]?.event, "error");
+  const error = JSON.parse(terminal[0]?.data ?? "{}");
   assert.equal(error.code, "CALCULATION_FAILED");
   assert.ok(!error.message.includes("secret internal detail"));
+  const release = admission.tryAcquire();
+  assert.ok(release, "generic factory failure must release admission");
+  release();
 });
 
 test("every successful stream ends with exactly one terminal event and a trailing blank line", async () => {

--- a/test/meeting-stream.test.ts
+++ b/test/meeting-stream.test.ts
@@ -310,6 +310,22 @@ test("provider factory throws one safe terminal SSE error event", async () => {
   release();
 });
 
+test("RangeError from provider factory stays a safe generic terminal SSE error", async () => {
+  const response = await handleMeetingStreamPost(streamRequest(), () => {
+    throw new RangeError("secret");
+  }, { admission: new ScheduledCalculationAdmission() });
+  assert.equal(response.status, 200);
+  assert.equal(response.headers.get("content-type"), "text/event-stream");
+  const frames = parseSseFrames(await response.text());
+  const terminal = frames.filter((frame) => frame.event === "result" || frame.event === "error");
+  assert.equal(terminal.length, 1);
+  assert.equal(terminal[0]?.event, "error");
+  const error = JSON.parse(terminal[0]?.data ?? "{}");
+  assert.equal(error.code, "CALCULATION_FAILED");
+  assert.equal(error.message, "The scheduled meeting calculation could not be completed.");
+  assert.equal(JSON.stringify(error).includes("secret"), false);
+});
+
 test("every successful stream ends with exactly one terminal event and a trailing blank line", async () => {
   const response = await handleMeetingStreamPost(streamRequest(), PROVIDERS, { admission: new ScheduledCalculationAdmission() });
   const body = await response.text();


### PR DESCRIPTION
## Summary
- reject invalid v3 calculation and details requests before admission or provider setup
- return safe configuration failures across calculation, stream, and details adapters
- preserve terminal SSE failures while preventing setup/error detail leaks

## Verification
- npm test
- npm run lint
- npx tsc --noEmit
- git diff --check origin/dev...HEAD

Closes #102